### PR TITLE
feat: 支持前端显示和编辑sortName

### DIFF
--- a/MaiChartManager/Controllers/Music/MusicController.cs
+++ b/MaiChartManager/Controllers/Music/MusicController.cs
@@ -27,6 +27,19 @@ public class MusicController(StaticSettings settings, ILogger<MusicController> l
             music.Name = value;
         }
     }
+    
+    [HttpPost]
+    public string EditMusicSortName(int id, [FromBody] string value, string assetDir)
+    {
+        var music = settings.GetMusic(id, assetDir);
+        if (music != null)
+        {
+            music.SortName = value;
+            return music.SortName; // 因为music.SortName的setter中会对内容做格式化、确保符合要求。所以把转化的结果返回前端供前端更新。
+        }
+
+        return "";
+    }
 
     [HttpPost]
     public void EditMusicArtist(int id, [FromBody] string value, string assetDir)

--- a/MaiChartManager/Front/src/client/apiGen.ts
+++ b/MaiChartManager/Front/src/client/apiGen.ts
@@ -251,6 +251,7 @@ export interface MusicXmlWithABJacket {
   nonDxId?: number;
   modified?: boolean;
   name?: string | null;
+  sortName?: string | null;
   /** @format int32 */
   genreId?: number;
   /** @format int32 */
@@ -1590,6 +1591,23 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         method: "POST",
         body: data,
         type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Music
+     * @name EditMusicSortName
+     * @request POST:/MaiChartManagerServlet/EditMusicSortNameApi/{assetDir}/{id}
+     */
+    EditMusicSortName: (id: number, assetDir: string, data: string, params: RequestParams = {}) =>
+      this.request<string, any>({
+        path: `/MaiChartManagerServlet/EditMusicSortNameApi/${assetDir}/${id}`,
+        method: "POST",
+        body: data,
+        type: ContentType.Json,
+        format: "json",
         ...params,
       }),
 

--- a/MaiChartManager/Front/src/components/MusicEdit/index.tsx
+++ b/MaiChartManager/Front/src/components/MusicEdit/index.tsx
@@ -1,8 +1,8 @@
 import { computed, defineComponent, onMounted, PropType, ref, watch } from "vue";
-import { Chart, GenreXml, MusicXmlWithABJacket } from "@/client/apiGen";
+import { Chart, GenreXml, MusicXmlWithABJacket, ShiftMethod } from "@/client/apiGen";
 import { addVersionList, genreList, globalCapture, selectedADir, selectedMusic as info, selectMusicId, updateAddVersionList, updateGenreList, updateMusicList, selectedLevel } from "@/store/refs";
 import api from "@/client/api";
-import { NButton, NFlex, NForm, NFormItem, NInput, NInputNumber, NSelect, NSwitch, NTabPane, NTabs, SelectOption, useDialog, useMessage } from "naive-ui";
+import { NButton, NFlex, NForm, NFormItem, NInput, NInputNumber, NPopover, NRadio, NSelect, NSwitch, NTabPane, NTabs, SelectOption, useDialog, useMessage } from "naive-ui";
 import JacketBox from "../JacketBox";
 import dxIcon from "@/assets/dxIcon.png";
 import stdIcon from "@/assets/stdIcon.png";
@@ -29,7 +29,12 @@ const Component = defineComponent({
     const sync = (key: keyof MusicXmlWithABJacket, method: Function) => async () => {
       if (!info.value) return;
       info.value!.modified = true;
-      await method(info.value.id!, info.value.assetDir, (info.value as any)[key]!);
+      const value = (info.value as any)[key];
+      const result = (await method(info.value.id!, info.value.assetDir, value)).data;
+      if (key === "sortName" && typeof result === "string" && result !== value) {
+        // 如果调用的是sortName接口，且返回的字符串（经过格式化后的实际内容）和传过去的值不同的话，则覆盖之
+        info.value!.sortName = result;
+      }
     }
 
     watch(() => info.value?.name, sync('name', api.EditMusicName));
@@ -41,6 +46,7 @@ const Component = defineComponent({
     watch(() => info.value?.utageKanji, sync('utageKanji', api.EditMusicUtageKanji));
     watch(() => info.value?.comment, sync('comment', api.EditMusicComment));
     watch(() => info.value?.longMusic, sync('longMusic', api.EditMusicLong));
+    watch(() => info.value?.sortName, sync('sortName', api.EditMusicSortName))
 
     onMounted(()=>{
       if ('mediaSession' in navigator) {
@@ -103,6 +109,14 @@ const Component = defineComponent({
                       <NInput v-model:value={info.value.comment}/>
                   </NFormItem>
               </>}
+            <NFormItem label={t('music.edit.sortName')}>
+              <NPopover trigger="hover">
+                {{
+                  trigger: () => <NInput v-model:value={info.value!.sortName} class="w-0 grow"/>,
+                  default: () => <div>{t('music.edit.sortNameTips')}</div>
+                }}
+              </NPopover>
+            </NFormItem>
             <AcbAwb song={info.value}/>
             <NTabs type="line" animated barWidth={0} v-model:value={selectedLevel.value} class="levelTabs"
                    style={{'--n-tab-padding': 0, '--n-pane-padding-top': 0, '--n-tab-text-color-hover': ''}}>

--- a/MaiChartManager/Front/src/locales/en.yaml
+++ b/MaiChartManager/Front/src/locales/en.yaml
@@ -84,6 +84,8 @@ music:
     addVersion: Add Version
     utageType: Utage Type
     utageComment: Utage Comment
+    sortName: In-game SortName
+    sortNameTips: May only contain digits, uppercase letters, and katakana; invalid characters will be automatically replaced
     jacket: Jacket
     audioPreview: Preview
     editPreview: Edit Preview

--- a/MaiChartManager/Front/src/locales/zh-TW.yaml
+++ b/MaiChartManager/Front/src/locales/zh-TW.yaml
@@ -82,6 +82,8 @@ music:
     addVersion: 追加版本
     utageType: 宴譜種類
     utageComment: 宴譜備註
+    sortName: 遊戲內排序名
+    sortNameTips: 只能包含數字、大寫字母、片假名（若有不合要求的字元，會被自動替換）
     jacket: 封面
     audioPreview: 試聽
     editPreview: 編輯預覽

--- a/MaiChartManager/Front/src/locales/zh.yaml
+++ b/MaiChartManager/Front/src/locales/zh.yaml
@@ -82,6 +82,8 @@ music:
     addVersion: 追加版本
     utageType: 宴谱种类
     utageComment: 宴谱备注
+    sortName: 游戏内排序名
+    sortNameTips: 只能包含数字、大写字母、片假名（如有不合要求的字符，会被自动替换）
     jacket: 封面
     audioPreview: 试听
     editPreview: 编辑预览

--- a/MaiChartManager/Models/MusicXml.cs
+++ b/MaiChartManager/Models/MusicXml.cs
@@ -240,6 +240,16 @@ public partial class MusicXml
             RootNode.SelectSingleNode("name/str").InnerText = value;
             RootNode.SelectSingleNode("movieName/str").InnerText = value;
             RootNode.SelectSingleNode("cueName/str").InnerText = value;
+            SortName = value;
+        }
+    }
+
+    public string SortName
+    {
+        get => RootNode.SelectSingleNode("sortName")?.InnerText ?? "";
+        set
+        {
+            Modified = true;
             RootNode.SelectSingleNode("sortName").InnerText = ConvertSortName(value);
         }
     }


### PR DESCRIPTION
支持前端显示和编辑sortName，编辑的sortName会被自动处理确保符合要求。

PS：动机：我自己写洛天依的中文歌比如《蝴蝶》，然后会被MCM自动生成sortName为`コチョウ`，有点难绷x  现在我至少可以导入后自己手动改为`HUDIE`了。