### PR TITLE
fix: 多线程并行导出谱面的相关问题

### DIFF
--- a/.idea/.idea.Sitreamai/.idea/vcs.xml
+++ b/.idea/.idea.Sitreamai/.idea/vcs.xml
@@ -7,5 +7,6 @@
     <mapping directory="$PROJECT_DIR$/SimaiSharp" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/SonicAudioTools" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/XV2-Tools" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/MuNET-UI" vcs="Git" />
   </component>
 </project>

--- a/MaiChartManager/Controllers/Music/MusicTransferController.cs
+++ b/MaiChartManager/Controllers/Music/MusicTransferController.cs
@@ -656,17 +656,16 @@ public class MusicTransferController(StaticSettings settings, ILogger<MusicTrans
             Comment = version?.GenreName,
             AlbumArt = img,
         };
-        var wavPath = await AudioConvert.GetCachedWavPath(GetAudioCandidateIds(music));
-        if (wavPath is null)
+        
+        if (!AudioConvert.TryResolveAcbAwb(GetAudioCandidateIds(music), out _, out var acbPath, out var awbPath) || acbPath is null || awbPath is null)
         {
             var message = BuildAudioResolveErrorMessage(music);
             logger.LogError("{message}", message);
             throw new FileNotFoundException(message);
         }
-
-        AudioConvert.ConvertWavPathToMp3Stream(wavPath, soundStream, tag);
+        var wav = Audio.AcbToWav(acbPath);
+        AudioConvert.ConvertWavToMp3Stream(wav, soundStream, tag);
         soundStream.Close();
-        System.IO.File.Delete(wavPath);
 
         if (!ignoreVideo && StaticSettings.MovieDataMap.TryGetValue(music.NonDxId, out var movieUsmPath))
         {

--- a/MaiChartManager/Controllers/Music/MusicTransferController.cs
+++ b/MaiChartManager/Controllers/Music/MusicTransferController.cs
@@ -666,6 +666,7 @@ public class MusicTransferController(StaticSettings settings, ILogger<MusicTrans
 
         AudioConvert.ConvertWavPathToMp3Stream(wavPath, soundStream, tag);
         soundStream.Close();
+        System.IO.File.Delete(wavPath);
 
         if (!ignoreVideo && StaticSettings.MovieDataMap.TryGetValue(music.NonDxId, out var movieUsmPath))
         {

--- a/MaiChartManager/Utils/Audio.cs
+++ b/MaiChartManager/Utils/Audio.cs
@@ -11,7 +11,11 @@ public static class Audio
 {
     public static void ConvertToMai(string srcPath, string savePath, float padding = 0, Stream? src = null, string? previewFilename = null, Stream? preview = null, bool forceUseNAudio = false)
     {
-        var wrapper = new ACB_Wrapper(ACB_File.Load(File.ReadAllBytes(Path.Combine(StaticSettings.exeDir, previewFilename is null ? "nopreview.acb" : "template.acb")), null));
+        ACB_File acbTemplate;
+        lock (_acbFileLoadLock) {
+            acbTemplate = ACB_File.Load(File.ReadAllBytes(Path.Combine(StaticSettings.exeDir, previewFilename is null ? "nopreview.acb" : "template.acb")), null);
+        }
+        var wrapper = new ACB_Wrapper(acbTemplate);
         var trackBytes = LoadAndConvertFile(srcPath, FileType.Hca, false, 9170825592834449000, padding, src, forceUseNAudio);
 
         wrapper.Cues[0].AddTrackToCue(trackBytes, true, false, EncodeType.HCA);
@@ -173,12 +177,12 @@ public static class Audio
         }
     }
     
-    private static readonly object _acbToWavLock = new object();
+    private static readonly object _acbFileLoadLock = new();
 
     public static byte[] AcbToWav(string acbPath)
     {
         ACB_File acb;
-        lock (_acbToWavLock) {
+        lock (_acbFileLoadLock) {
             acb = ACB_File.Load(acbPath);
         }
         var wave = acb.GetWaveformsFromCue(acb.Cues[0])[0];

--- a/MaiChartManager/Utils/Audio.cs
+++ b/MaiChartManager/Utils/Audio.cs
@@ -172,10 +172,15 @@ public static class Audio
                 return FileType.NotSet;
         }
     }
+    
+    private static readonly object _acbToWavLock = new object();
 
     public static byte[] AcbToWav(string acbPath)
     {
-        var acb = ACB_File.Load(acbPath);
+        ACB_File acb;
+        lock (_acbToWavLock) {
+            acb = ACB_File.Load(acbPath);
+        }
         var wave = acb.GetWaveformsFromCue(acb.Cues[0])[0];
         var entry = acb.GetAfs2Entry(wave.AwbId);
         using MemoryStream stream = new MemoryStream(entry.bytes);

--- a/MaiChartManager/Utils/AudioConvert.cs
+++ b/MaiChartManager/Utils/AudioConvert.cs
@@ -73,23 +73,26 @@ public static class AudioConvert
         return cachePath;
     }
 
-    public static void ConvertWavPathToMp3Stream(string wavPath, Stream mp3Stream, ID3TagData? tagData = null)
+    public static void ConvertWavToMp3Stream(byte[] wav, Stream mp3Stream, ID3TagData? tagData = null)
     {
-        var outputPath = Path.Combine(StaticSettings.tempPath, $"ConvertToMp3_{Guid.NewGuid():N}.mp3");
+        var tempFileGuid = Guid.NewGuid();
+        var inputPath = Path.Combine(StaticSettings.tempPath, $"ConvertToMp3_{tempFileGuid:N}.wav");
+        var outputPath = Path.Combine(StaticSettings.tempPath, $"ConvertToMp3_{tempFileGuid:N}.mp3");
         string? albumArtPath = null;
         try
         {
             Directory.CreateDirectory(StaticSettings.tempPath);
+            File.WriteAllBytes(inputPath, wav);
 
             var conversion = FFmpeg.Conversions.New()
-                .AddParameter($"-i " + FFmpegHelper.Escape(wavPath));
+                .AddParameter($"-i " + FFmpegHelper.Escape(inputPath));
 
             if (tagData != null)
             {
                 if (tagData.AlbumArt != null && tagData.AlbumArt.Length > 0)
                 {
                     // 把专辑封面写到临时文件，然后让ffmpeg把它嵌入mp3
-                    albumArtPath = Path.Combine(StaticSettings.tempPath, $"ConvertToMp3_{Guid.NewGuid():N}.png");
+                    albumArtPath = Path.Combine(StaticSettings.tempPath, $"ConvertToMp3_{tempFileGuid:N}.png");
                     File.WriteAllBytes(albumArtPath, tagData.AlbumArt);
                     conversion.AddParameter($"-i {FFmpegHelper.Escape(albumArtPath)}");
                 } // 顺序不能换！这个必须在第一个，因为-i必须在任何其他参数之前。
@@ -122,6 +125,7 @@ public static class AudioConvert
         }
         finally
         {
+            File.Delete(inputPath);
             File.Delete(outputPath);
             if (albumArtPath != null) File.Delete(albumArtPath);
         }


### PR DESCRIPTION
#### 9327467 : 修复多线程批量导出谱面时，并发未加锁调用ACB_Load引起的问题
我在我的电脑上尝试批量导出1000多张所有谱面的时候，发生报错：
```
fail: Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware[1]
      An unhandled exception has occurred while executing the request.
      System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
         at System.Collections.Generic.List`1.Enumerator.MoveNext()
         at Xv2CoreLib.ACB.AcbFormatHelperTable.ParseTable(UTF_File table, String tableName, Version version, Boolean throwExIfNewColumn, Boolean supressErrors) in C:\Users\ZYN\Desktop\MaiChartManager\XV2-Tools\Xv2CoreLib\ACB\FormatHelper.cs:line 300
         at Xv2CoreLib.ACB.AcbFormatHelperMain.ParseFile(UTF_File acbFile, Boolean throwExIfNewColumn, Boolean suppressErrors) in C:\Users\ZYN\Desktop\MaiChartManager\XV2-Tools\Xv2CoreLib\ACB\FormatHelper.cs:line 219
         at Xv2CoreLib.ACB.AcbFormatHelper.ParseFile(UTF_File utfFile, Boolean suppressErrors) in C:\Users\ZYN\Desktop\MaiChartManager\XV2-Tools\Xv2CoreLib\ACB\FormatHelper.cs:line 28
         at Xv2CoreLib.ACB.ACB_File.Load(UTF_File utfFile, IAwbFile awbFile, Boolean loadUnknownCommands, Boolean isAudioPackage, Boolean eternityCompatibility, Boolean altAwbPath) in C:\Users\ZYN\Desktop\MaiChartManager\XV2-Tools\Xv2CoreLib\ACB\ACB_File.cs:line 321
         at Xv2CoreLib.ACB.ACB_File.Load(Byte[] acbBytes, IAwbFile awbFile, Boolean loadUnknownCommands, Boolean isAudioPackage, Boolean altAwbPath) in C:\Users\ZYN\Desktop\MaiChartManager\XV2-Tools\Xv2CoreLib\ACB\ACB_File.cs:line 313
         at Xv2CoreLib.ACB.ACB_File.Load(String path, Boolean writeXml) in C:\Users\ZYN\Desktop\MaiChartManager\XV2-Tools\Xv2CoreLib\ACB\ACB_File.cs:line 300
         at MaiChartManager.Utils.Audio.AcbToWav(String acbPath) in C:\Users\ZYN\Desktop\MaiChartManager\MaiChartManager\Utils\Audio.cs:line 178
         at MaiChartManager.Utils.AudioConvert.GetCachedWavPath(String acbPath, String awbPath) in C:\Users\ZYN\Desktop\MaiChartManager\MaiChartManager\Utils\AudioConvert.cs:line 71
         at MaiChartManager.Utils.AudioConvert.GetCachedWavPath(Int32[] musicIds) in C:\Users\ZYN\Desktop\MaiChartManager\MaiChartManager\Utils\AudioConvert.cs:line 57
         at MaiChartManager.Controllers.Music.MusicTransferController.ExportAsMaidata(Int32 id, String assetDir, Boolean ignoreVideo) in C:\Users\ZYN\Desktop\MaiChartManager\MaiChartManager\Controllers\Music\MusicTransferController.cs:line 659
         at MaiChartManager.Controllers.Music.MusicTransferController.ExportAsMaidata(Int32 id, String assetDir, Boolean ignoreVideo) in C:\Users\ZYN\Desktop\MaiChartManager\MaiChartManager\Controllers\Music\MusicTransferController.cs:line 715
         at MaiChartManager.Controllers.Music.MusicTransferController.ExportAsMaidata(Int32 id, String assetDir, Boolean ignoreVideo) in C:\Users\ZYN\Desktop\MaiChartManager\MaiChartManager\Controllers\Music\MusicTransferController.cs:line 715
         ...... 以下省略
```

经查，报错报在XV2-tools内部，核心是 https://github.com/clansty/XV2-Tools/blob/fa0e9758f2be733a2b76c236735d02b9e4f89000/Xv2CoreLib/ACB/FormatHelper.cs#L299-L304
在迭代`Columns`时，`Columns`被从外部改变。

为什么会这样呢？注意到`Columns`是定义在`AcbFormatHelperTable`，并由`AcbFormatHelper`引用的。然而：
https://github.com/clansty/XV2-Tools/blob/53bdb59d89f207aa941a59bd943105a88a74eaf0/Xv2CoreLib/ACB/ACB_File.cs#L316-L324
`ACB_File.Load`中是通过单例模式调用的全局共享的`AcbFormatHelper`实例！因此，当多个线程同时调用`ACB_File.Load`时，就会引起对这个`AcbFormatHelper`的并发冲突问题。

要想根除这个问题，唯一的办法是重构XV2-tools、改为每个实例独立的Loader的模式，然而这需要对XV2-tools进行大幅度的研究和重构，我本人暂无这个精力。

所以目前我们在MCM侧的规避方案就是给`ACB_File.Load`的调用加锁。

#### 3512c82：批量导出谱面时，wav文件生成后不会被自动删除造成硬盘爆炸的问题（commit message打错成内存了、懒得改了）

我批量导出1000多个谱面，导出到一半，`C:\Users\username\AppData\Local\Temp\MaiChartManager`就占用了近20G磁盘，把我C盘吃满导出失败了。所以最好是每次导出后、删除所生成的wav缓存文件。相当于加了个缓存清理机制。

#### 766c1f4: 在.idea/vcs.xml中添加对MuNET-UI的submodule的引用，不然Rider上会有一些不便。

## Summary by Sourcery

在多线程谱面导出中对 ACB 音频加载进行保护，并在导出后清理临时音频文件以避免资源问题。

Bug 修复：
- 在音频转换中串行化对 `ACB_File.Load` 的调用，防止在批量谱面导出时出现多线程并发错误。
- 在将临时生成的 `wav` 文件转换为 `MP3` 后删除这些文件，以避免临时目录无限增长。

改进：
- 更新 IDE VCS 配置以跟踪 `MuNET-UI` 子模块，从而提升开发体验。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Guard ACB audio loading used in multi-threaded chart export and clean up temporary audio files after export to avoid resource issues.

Bug Fixes:
- Serialize calls to ACB_File.Load in audio conversion to prevent multi-threading concurrency errors during batch chart export.
- Delete generated temporary wav files after converting them to MP3 to avoid unbounded growth of the temp directory.

Enhancements:
- Update IDE VCS configuration to track the MuNET-UI submodule for improved development experience.

</details>