### PR TITLE
feat: add MelonLoader version check to prevent crashes (#36)

### DIFF
--- a/MaiChartManager/Launcher.cs
+++ b/MaiChartManager/Launcher.cs
@@ -158,6 +158,25 @@ public partial class Launcher : Form
             return;
         }
 
+        string mlDllPath = Path.Combine(StaticSettings.GamePath, "..", "MelonLoader", "MelonLoader.dll");
+        if (File.Exists(mlDllPath))
+        {
+            var versionInfo = System.Diagnostics.FileVersionInfo.GetVersionInfo(mlDllPath);
+            string? version = versionInfo.ProductVersion;
+
+            if (version == null || !version.StartsWith("0.6.4"))
+            {
+                var dialougResult = MessageBox.Show(
+                    // Add i8n pls :)
+                    $"Detected MelonLoader version {version}, but 0.6.4 is recommended for stability. Continue anyway?",
+                    "MelonLoader Version Warning",
+                    MessageBoxButtons.YesNo,
+                    MessageBoxIcon.Warning);
+
+                if (dialougResult == DialogResult.No) return;
+            }
+        }
+
         if (ContainsSpecialCharacters(StaticSettings.GamePath))
         {
             MessageBox.Show(Locale.PathContainsSpecialChars, Locale.PathContainsSpecialCharsTitle, MessageBoxButtons.OK, MessageBoxIcon.Warning);

--- a/MaiChartManager/Launcher.cs
+++ b/MaiChartManager/Launcher.cs
@@ -158,23 +158,36 @@ public partial class Launcher : Form
             return;
         }
 
-        string mlDllPath = Path.Combine(StaticSettings.GamePath, "..", "MelonLoader", "MelonLoader.dll");
-        if (File.Exists(mlDllPath))
+        try
         {
-            var versionInfo = System.Diagnostics.FileVersionInfo.GetVersionInfo(mlDllPath);
-            string? version = versionInfo.ProductVersion;
-
-            if (version == null || !version.StartsWith("0.6.4"))
+            string mlDllPath = Path.Combine(StaticSettings.GamePath, "MelonLoader", "MelonLoader.dll");
+            if (!File.Exists(mlDllPath))
             {
-                var dialougResult = MessageBox.Show(
-                    // Add i8n pls :)
-                    $"Detected MelonLoader version {version}, but 0.6.4 is recommended for stability. Continue anyway?",
-                    "MelonLoader Version Warning",
-                    MessageBoxButtons.YesNo,
-                    MessageBoxIcon.Warning);
-
-                if (dialougResult == DialogResult.No) return;
+                mlDllPath = Path.Combine(StaticSettings.GamePath, "..", "MelonLoader", "MelonLoader.dll");
             }
+
+            if (File.Exists(mlDllPath))
+            {
+                var versionInfo = System.Diagnostics.FileVersionInfo.GetVersionInfo(mlDllPath);
+                string version = versionInfo.ProductVersion ?? "unknown";
+
+                if (!version.StartsWith("0.6.4"))
+                {
+                    // i8n pls
+                    var dialogResult = MessageBox.Show(
+                        $"Detected MelonLoader version {version}, but 0.6.4 is recommended for stability. Continue anyway?",
+                        "MelonLoader Version Warning",
+                        MessageBoxButtons.YesNo,
+                        MessageBoxIcon.Warning);
+
+                    if (dialogResult == DialogResult.No) return;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+             // add i8n, pleeeeease
+            Console.WriteLine($"Failed to check MelonLoader version: {ex.Message}");
         }
 
         if (ContainsSpecialCharacters(StaticSettings.GamePath))

--- a/MaiChartManager/Launcher.cs
+++ b/MaiChartManager/Launcher.cs
@@ -186,8 +186,12 @@ public partial class Launcher : Form
         }
         catch (Exception ex)
         {
-             // add i8n, pleeeeease
-            Console.WriteLine($"Failed to check MelonLoader version: {ex.Message}");
+            // add i8n, pleeeeease
+            MessageBox.Show(
+                            $"Failed to check MelonLoader version: {ex.Message}. Please ensure MelonLoader 0.6.4 is installed.",
+                            "MelonLoader Check Error",
+                            MessageBoxButtons.OK,
+                            MessageBoxIcon.Warning);
         }
 
         if (ContainsSpecialCharacters(StaticSettings.GamePath))
@@ -208,7 +212,7 @@ public partial class Launcher : Form
         StaticSettings.Config.AuthUsername = textBoxLanAuthUser.Text;
         StaticSettings.Config.AuthPassword = textBoxLanAuthPass.Text;
         StaticSettings.Config.Save();
-# endif
+#endif
 
         textBox1.Enabled = false;
         button1.Enabled = false;


### PR DESCRIPTION
## Description
This PR implements a version check for MelonLoader as requested in #36. 

It checks `MelonLoader.dll` in the game directory. If the version is not **0.6.4** (which is known to be stable for MCM), a warning dialog is displayed, allowing the user to either cancel the launch or proceed at their own risk.

## Changes
- Added version verification logic in `Launcher.cs`
- Included a warning MessageBox for incompatible versions

Add i8n pls)))

Closes #36

## Summary by Sourcery

在启动器中添加 MelonLoader 版本检查功能，在启动游戏前提醒用户当前版本可能不稳定。

新功能：
- 基于游戏目录中的 `MelonLoader.dll` 实现对已安装 MelonLoader 版本的运行时检测。
- 当检测到非推荐的 MelonLoader 版本时，显示确认对话框，让用户选择取消或继续。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a MelonLoader version check in the launcher to warn users about potentially unstable versions before starting the game.

New Features:
- Introduce runtime detection of the installed MelonLoader version based on MelonLoader.dll in the game directory.
- Display a confirmation dialog allowing users to cancel or proceed when a non‑recommended MelonLoader version is detected.

</details>