### PR TITLE
MuConvert 更新到v0.3.0

### DIFF
--- a/MaiChartManager/Controllers/Charts/ChartPreviewController.cs
+++ b/MaiChartManager/Controllers/Charts/ChartPreviewController.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using MuConvert.generator;
-using MuConvert.parser;
+using MuConvert.mai;
 
 namespace MaiChartManager.Controllers.Charts;
 

--- a/MaiChartManager/Controllers/Charts/ImportChartController.cs
+++ b/MaiChartManager/Controllers/Charts/ImportChartController.cs
@@ -1,10 +1,7 @@
 ﻿using MaiChartManager.Controllers.Charts.Services;
 using MaiChartManager.Controllers.Music;
 using Microsoft.AspNetCore.Mvc;
-using MuConvert.chart;
-using MuConvert.generator;
-using MuConvert.maidata;
-using MuConvert.parser;
+using MuConvert.mai;
 using MuConvert.utils;
 
 namespace MaiChartManager.Controllers.Charts;
@@ -88,7 +85,7 @@ public class ImportChartController(StaticSettings settings, ILogger<StaticSettin
 
             var first = maiData.First;
             var isDx = false;
-            List<Chart> resultCharts = [];
+            List<MaiChart> resultCharts = [];
             List<SimaiSharp.Structures.MaiChart> legacyCharts = [];
             foreach (var (lv, data) in maiData.Levels)
             {

--- a/MaiChartManager/Controllers/Charts/Services/MaidataImportService.cs
+++ b/MaiChartManager/Controllers/Charts/Services/MaidataImportService.cs
@@ -1,9 +1,6 @@
 ﻿using MaiChartManager.Models;
 using MaiChartManager.Utils;
-using MuConvert.chart;
-using MuConvert.generator;
-using MuConvert.maidata;
-using MuConvert.parser;
+using MuConvert.mai;
 using MuConvert.utils;
 using Rationals;
 
@@ -65,7 +62,7 @@ public class MaidataImportService : IMaidataImportService
         this.logger = logger;
     }
 
-    public static Dictionary<ShiftMethod, (double sec, decimal bpm, Rational bar)> CalcChartPadding(List<Chart> charts)
+    public static Dictionary<ShiftMethod, (double sec, decimal bpm, Rational bar)> CalcChartPadding(List<MaiChart> charts)
     {
         // 谱面导入时，会有两个地方涉及到时间的调整：
         // 1. 对谱面的调整。在下方的ImportMaidata函数中应用，对谱面进行相应的调整（chart.Shift）。
@@ -85,7 +82,7 @@ public class MaidataImportService : IMaidataImportService
         var notePaddingOfEachChart = charts.Select(chart =>
         {
             var bpm = chart.StartBpm;
-            var notePadding = (1 - chart.FirstNoteTime.InvariantBar).CanonicalForm;
+            var notePadding = (1 - chart.StartTime.InvariantBar).CanonicalForm;
             var sec = (double)(notePadding * (240 / (Rational)bpm));
             return (sec, bpm, notePadding);
         }).ToList();
@@ -195,7 +192,7 @@ public class MaidataImportService : IMaidataImportService
         }
         
         // 先执行第一步：Parser，因为可能涉及对Chart做出调整
-        List<(int lv, int targetLevel, MaidataChart data, Chart chart, List<Alert> alerts)> parserOutput = [];
+        List<(int lv, int targetLevel, MaidataLevel data, MaiChart chart, List<Alert> alerts)> parserOutput = [];
         foreach (var (lv, data) in maiData.Levels)
         {
             if (!targetLevelMap.ContainsKey(lv)) continue;

--- a/MaiChartManager/Controllers/Music/MusicTransferController.cs
+++ b/MaiChartManager/Controllers/Music/MusicTransferController.cs
@@ -7,9 +7,7 @@ using MaiChartManager.Models;
 using MaiChartManager.Utils;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.VisualBasic.FileIO;
-using MuConvert.generator;
-using MuConvert.maidata;
-using MuConvert.parser;
+using MuConvert.mai;
 using NAudio.Lame;
 using Vanara.Windows.Forms;
 using FolderBrowserDialog = System.Windows.Forms.FolderBrowserDialog;
@@ -679,7 +677,7 @@ public partial class MusicTransferController(StaticSettings settings, ILogger<Mu
                     var simai = ma2.Compose(MaiLib.ChartEnum.ChartVersion.SimaiFes);
 
                     var lvStr = $"{chart.Level}.{chart.LevelDecimal}";
-                    simaiFile.AddLevel(i + 2, new MaidataChart(simai, lvStr, chart.Designer), false);
+                    simaiFile.AddLevel(i + 2, new MaidataLevel(simai, lvStr, chart.Designer), false);
                 }
                 else
                 {
@@ -688,7 +686,7 @@ public partial class MusicTransferController(StaticSettings settings, ILogger<Mu
                     var (simai, _) = new SimaiGenerator().Generate(cvtChart);
 
                     var lvStr = $"{chart.Level}.{chart.LevelDecimal}";
-                    simaiFile.AddLevel(i + 2, new MaidataChart(simai, lvStr, chart.Designer));
+                    simaiFile.AddLevel(i + 2, new MaidataLevel(simai, lvStr, chart.Designer));
                     simaiFile.ClockCount = cvtChart.ClockCount; // 通过多次写入，自然实现取最后一个有效难度的clockCount，作为写入maidata中的
                 }
             }


### PR DESCRIPTION
MuConvert v0.3.0，主要的特性是支持了中二转谱
对我们这边的影响是，由于重构，对命名空间格式和部分类的类名做出了一些调整，因此MCM这边也需要加以适配。

本PR将MuConvert更新到`MuConvert 0.3.0-beta+e5bfc86`，并适配了新版本的一些类的命名空间调整和类名调整等。

## 由 Sourcery 总结

将 MuConvert 集成更新到 v0.3.0，并根据新的 API 调整谱面导入/导出逻辑。

修复内容：
- 调整谱面边距（padding）计算方式，使用新的谱面开始时间属性，确保导入后时间偏移正确。

优化/增强：
- 切换到统一的 `MuConvert.mai` 命名空间，并在导入、导出和预览流程中，将与谱面和 maidata 相关的类型统一更新为新的 `MaiChart` 和 `MaidataLevel` 名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update MuConvert integration to v0.3.0 and adapt chart import/export logic to the new API.

Bug Fixes:
- Adjust chart padding calculation to use the new chart start time property, ensuring correct timing offsets after import.

Enhancements:
- Switch to the unified MuConvert.mai namespace and update chart- and maidata-related types to the new MaiChart and MaidataLevel names across import, export, and preview flows.

</details>