### PR TITLE
feat: 导入歌曲时，将图片转换为AssetBundle格式（默认开启，可关闭）；以及优化ImageToAbTool、ModifyId的逻辑。

### DIFF
--- a/MaiChartManager/Config.cs
+++ b/MaiChartManager/Config.cs
@@ -27,6 +27,7 @@ public class Config
     public bool IgnoreLevel { get; set; } = false;
     public bool DisableBga { get; set; } = false;
     public bool UseLegacyMaiLib { get; set; } = false;
+    public bool ConvertJacketToAssetBundle { get; set; } = true;
     public int UiZoom { get; set; } = 0;
 
     public void Save()

--- a/MaiChartManager/Controllers/App/SettingsController.cs
+++ b/MaiChartManager/Controllers/App/SettingsController.cs
@@ -11,6 +11,7 @@ public class SettingsDto
     public bool IgnoreLevel { get; set; }
     public bool DisableBga { get; set; }
     public bool UseLegacyMaiLib { get; set; }
+    public bool ConvertJacketToAssetBundle { get; set; }
     public int UiZoom { get; set; }
     public double TargetDpiScale { get; set; }
 }
@@ -30,6 +31,7 @@ public class SettingsController : ControllerBase
             IgnoreLevel = StaticSettings.Config.IgnoreLevel,
             DisableBga = StaticSettings.Config.DisableBga,
             UseLegacyMaiLib = StaticSettings.Config.UseLegacyMaiLib,
+            ConvertJacketToAssetBundle = StaticSettings.Config.ConvertJacketToAssetBundle,
             UiZoom = StaticSettings.Config.UiZoom,
             TargetDpiScale = Browser.TargetDpiScale,
         };
@@ -44,6 +46,7 @@ public class SettingsController : ControllerBase
         StaticSettings.Config.IgnoreLevel = dto.IgnoreLevel;
         StaticSettings.Config.DisableBga = dto.DisableBga;
         StaticSettings.Config.UseLegacyMaiLib = dto.UseLegacyMaiLib;
+        StaticSettings.Config.ConvertJacketToAssetBundle = dto.ConvertJacketToAssetBundle;
         StaticSettings.Config.Save();
     }
 }

--- a/MaiChartManager/Controllers/Music/MusicController.cs
+++ b/MaiChartManager/Controllers/Music/MusicController.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using AssetStudio;
 using MaiChartManager.Models;
 using MaiChartManager.Utils;
@@ -157,7 +157,6 @@ public class MusicController(StaticSettings settings, ILogger<MusicController> l
     [HttpPut]
     public string SetMusicJacket(int id, IFormFile file, string assetDir)
     {
-        var nonDxId = id % 10000;
         var ext = Path.GetExtension(file.FileName).ToLowerInvariant();
         if (!MusicXml.jacketExtensions.Contains(ext[1..]))
         {
@@ -165,19 +164,32 @@ public class MusicController(StaticSettings settings, ILogger<MusicController> l
         }
 
         var music = settings.GetMusic(id, assetDir);
-        while (music?.JacketPath is not null && System.IO.File.Exists(music.JacketPath))
-        {
-            FileSystem.DeleteFile(music.JacketPath, UIOption.OnlyErrorDialogs, RecycleOption.SendToRecycleBin);
-        }
+        if (music is null) return "Music not found!";
+        music.DeleteJacket(); // 删除老的jacket
 
         var abiDir = Path.Combine(StaticSettings.StreamingAssets, assetDir, @"AssetBundleImages\jacket");
         Directory.CreateDirectory(abiDir);
-        var path = Path.Combine(abiDir, $"ui_jacket_{nonDxId:000000}{ext}");
-        using var write = System.IO.File.Open(path, FileMode.Create);
-        file.CopyTo(write);
-        write.Close();
-        if (music is not null)
+        
+        if (StaticSettings.Config.ConvertJacketToAssetBundle)
+        { // 将图片转为AssetBundle
+            using var buffer = new MemoryStream();
+            file.CopyTo(buffer);
+            var imageBytes = buffer.ToArray();
+
+            var assetBundleDir = Path.GetDirectoryName(abiDir)!;
+            var resultAbPath = AssetBundleCreator.CreateMusicJacketAssetBundles(
+                imageBytes, assetBundleDir, music.NonDxId);
+            StaticSettings.AssetBundleJacketMap[music.NonDxId] = resultAbPath;
+        }
+        else
+        {
+            var path = Path.Combine(abiDir, "jacket", $"ui_jacket_{music.NonDxId:000000}{ext}");
+            using var write = System.IO.File.Open(path, FileMode.Create);
+            file.CopyTo(write);
+            write.Close();
             music.JacketPath = path;
+        }
+
         return "";
     }
 

--- a/MaiChartManager/Controllers/Music/MusicController.cs
+++ b/MaiChartManager/Controllers/Music/MusicController.cs
@@ -183,7 +183,7 @@ public class MusicController(StaticSettings settings, ILogger<MusicController> l
         }
         else
         {
-            var path = Path.Combine(abiDir, "jacket", $"ui_jacket_{music.NonDxId:000000}{ext}");
+            var path = Path.Combine(abiDir, $"ui_jacket_{music.NonDxId:000000}{ext}");
             using var write = System.IO.File.Open(path, FileMode.Create);
             file.CopyTo(write);
             write.Close();

--- a/MaiChartManager/Controllers/Music/MusicTransferController.cs
+++ b/MaiChartManager/Controllers/Music/MusicTransferController.cs
@@ -589,6 +589,9 @@ public partial class MusicTransferController(StaticSettings settings, ILogger<Mu
             
             DeleteAb(oldAb);
             if (oldSmallAb is not null) DeleteAb(oldSmallAb);
+
+            StaticSettings.AssetBundleJacketMap.Remove(music.NonDxId);
+            StaticSettings.AssetBundleJacketMap[newNonDxId] = abJacketTarget;
         }
         #endregion
 

--- a/MaiChartManager/Controllers/Music/MusicTransferController.cs
+++ b/MaiChartManager/Controllers/Music/MusicTransferController.cs
@@ -539,7 +539,7 @@ public partial class MusicTransferController(StaticSettings settings, ILogger<Mu
         var newMusicDir = Path.Combine(StaticSettings.StreamingAssets, assetDir, "music", $"music{newId:000000}");
         DeleteIfExists(abJacketTarget, abJacketTarget + ".manifest", abJacketSTarget, abJacketSTarget + ".manifest", acbawbTarget + ".acb", acbawbTarget + ".awb", movieTarget + ".dat", movieTarget + ".mp4", newMusicDir);
 
-        # region 移动或重打包封面图
+        #region 移动或重打包封面图
         var jacketSourcePath = music.JacketPath is not null ? music.JacketPath : music.PseudoAssetBundleJacket;
         if (jacketSourcePath is not null)
         {
@@ -551,7 +551,7 @@ public partial class MusicTransferController(StaticSettings settings, ILogger<Mu
         }
         else if (music.AssetBundleJacket is not null)
         {
-            var oldAb = music.AssetBundleJacket;
+            var oldAb = music.AssetBundleJacket!;
             var oldSmallAb = GetAssetBundleJacketSmallPath(oldAb);
             var idPad = $"{newNonDxId:000000}";
             logger.LogInformation("Repack jacket AB: {oldMainAb} -> {abJacketTarget}", oldAb, abJacketTarget);
@@ -588,7 +588,7 @@ public partial class MusicTransferController(StaticSettings settings, ILogger<Mu
             }
             
             DeleteAb(oldAb);
-            DeleteAb(oldSmallAb!);
+            if (oldSmallAb is not null) DeleteAb(oldSmallAb);
         }
         #endregion
 

--- a/MaiChartManager/Controllers/Music/MusicTransferController.cs
+++ b/MaiChartManager/Controllers/Music/MusicTransferController.cs
@@ -506,6 +506,13 @@ public partial class MusicTransferController(StaticSettings settings, ILogger<Mu
         }
     }
 
+    private void DeleteAb(string abPath)
+    {
+        FileSystem.DeleteFile(abPath, UIOption.OnlyErrorDialogs, RecycleOption.SendToRecycleBin);
+        if (System.IO.File.Exists(abPath + ".manifest"))
+            FileSystem.DeleteFile(abPath + ".manifest", UIOption.OnlyErrorDialogs, RecycleOption.SendToRecycleBin);
+    }
+
     [HttpPost]
     public async Task ModifyId(int id, [FromBody] int newId, string assetDir)
     {
@@ -521,16 +528,18 @@ public partial class MusicTransferController(StaticSettings settings, ILogger<Mu
         }
         var newNonDxId = newId % 10000;
 
-        var abJacketTarget = Path.Combine(StaticSettings.StreamingAssets, assetDir, "AssetBundleImages", "jacket", $"ui_jacket_{newNonDxId:000000}.ab");
-        var abJacketSTarget = Path.Combine(StaticSettings.StreamingAssets, assetDir, "AssetBundleImages", "jacket_s", $"ui_jacket_{newNonDxId:000000}_s.ab");
+        var abiDir = Path.Combine(StaticSettings.StreamingAssets, assetDir, @"AssetBundleImages\jacket");
+        var abiSDir = Path.Combine(StaticSettings.StreamingAssets, assetDir, @"AssetBundleImages\jacket_s");
+        Directory.CreateDirectory(abiDir);
+        Directory.CreateDirectory(abiSDir);
+        var abJacketTarget = Path.Combine(abiDir, $"ui_jacket_{newNonDxId:000000}.ab");
+        var abJacketSTarget = Path.Combine(abiSDir, $"ui_jacket_{newNonDxId:000000}_s.ab");
         var acbawbTarget = Path.Combine(StaticSettings.StreamingAssets, assetDir, "SoundData", $"music{newNonDxId:000000}");
         var movieTarget = Path.Combine(StaticSettings.StreamingAssets, assetDir, "MovieData", $"{newNonDxId:000000}");
         var newMusicDir = Path.Combine(StaticSettings.StreamingAssets, assetDir, "music", $"music{newId:000000}");
         DeleteIfExists(abJacketTarget, abJacketTarget + ".manifest", abJacketSTarget, abJacketSTarget + ".manifest", acbawbTarget + ".acb", acbawbTarget + ".awb", movieTarget + ".dat", movieTarget + ".mp4", newMusicDir);
-        var abiDir = Path.Combine(StaticSettings.StreamingAssets, assetDir, @"AssetBundleImages\jacket");
-        Directory.CreateDirectory(abiDir);
 
-        // jacket
+        # region 移动或重打包封面图
         var jacketSourcePath = music.JacketPath is not null ? music.JacketPath : music.PseudoAssetBundleJacket;
         if (jacketSourcePath is not null)
         {
@@ -542,29 +551,48 @@ public partial class MusicTransferController(StaticSettings settings, ILogger<Mu
         }
         else if (music.AssetBundleJacket is not null)
         {
-            // 否则需要执行转换逻辑
-            var localJacketTarget = Path.Combine(abiDir, $"ui_jacket_{newNonDxId:000000}.png");
-            logger.LogInformation("Convert jacket: {music.AssetBundleJacket} -> {abJacketTarget}", music.AssetBundleJacket, abJacketTarget);
-            System.IO.File.WriteAllBytes(localJacketTarget, music.GetMusicJacketPngData()!);
-            FileSystem.DeleteFile(music.AssetBundleJacket, UIOption.OnlyErrorDialogs, RecycleOption.SendToRecycleBin);
-            // AB→PNG: the old .ab.manifest no longer has a matching .ab at the new ID, so just delete it instead of moving
-            if (System.IO.File.Exists(music.AssetBundleJacket + ".manifest"))
+            var oldAb = music.AssetBundleJacket;
+            var oldSmallAb = GetAssetBundleJacketSmallPath(oldAb);
+            var idPad = $"{newNonDxId:000000}";
+            logger.LogInformation("Repack jacket AB: {oldMainAb} -> {abJacketTarget}", oldAb, abJacketTarget);
+            
+            // 重打包大jacket
+            AssetBundleCreator.RepackTextureAssetBundle(
+                oldAb,
+                abJacketTarget,
+                $"UI_Jacket_{idPad}",
+                $"assets/assetbundle/jacket/ui_jacket_{idPad}.png",
+                $"jacket/ui_jacket_{idPad}.ab");
+            
+            // 对小jacket：如果存在，重打包；如果不存在，则从png重新缩放，重新CreateTextureAssetBundle
+            if (oldSmallAb is not null && System.IO.File.Exists(oldSmallAb))
             {
-                FileSystem.DeleteFile(music.AssetBundleJacket + ".manifest", UIOption.OnlyErrorDialogs, RecycleOption.SendToRecycleBin);
+                AssetBundleCreator.RepackTextureAssetBundle(
+                    oldSmallAb,
+                    abJacketSTarget,
+                    $"UI_Jacket_{idPad}_s",
+                    $"assets/assetbundle/jacket_s/ui_jacket_{idPad}_s.png",
+                    $"jacket_s/ui_jacket_{idPad}_s.ab");
             }
-
-            // Issue #42: also clean up the companion jacket_s AB so it doesn't stay orphaned under the old ID
-            var oldJacketSPath = GetAssetBundleJacketSmallPath(music.AssetBundleJacket);
-            if (oldJacketSPath is not null && System.IO.File.Exists(oldJacketSPath))
+            else
             {
-                FileSystem.DeleteFile(oldJacketSPath, UIOption.OnlyErrorDialogs, RecycleOption.SendToRecycleBin);
-                if (System.IO.File.Exists(oldJacketSPath + ".manifest"))
-                {
-                    FileSystem.DeleteFile(oldJacketSPath + ".manifest", UIOption.OnlyErrorDialogs, RecycleOption.SendToRecycleBin);
-                }
+                var pngBytes = music.GetMusicJacketPngData();
+                AssetBundleCreator.CreateTextureAssetBundle(
+                    pngBytes,
+                    abJacketSTarget,
+                    $"UI_Jacket_{idPad}_s",
+                    $"assets/assetbundle/jacket_s/ui_jacket_{idPad}_s.png",
+                    $"jacket_s/ui_jacket_{idPad}_s.ab",
+                    resizeWidth: 200,
+                    resizeHeight: 200);
             }
+            
+            DeleteAb(oldAb);
+            DeleteAb(oldSmallAb!);
         }
+        #endregion
 
+        #region 移动音频和视频
         // 我也不知道它需不需要重新保存，先直接移动试试
         // 是可以的
         if (StaticSettings.AcbAwb.TryGetValue($"music{music.NonDxId:000000}.acb", out var acb))
@@ -585,6 +613,7 @@ public partial class MusicTransferController(StaticSettings settings, ILogger<Mu
             logger.LogInformation("Move movie: {movie} -> {movieTarget}", movie, movieTarget);
             FileSystem.MoveFile(movie, movieTarget + Path.GetExtension(movie), UIOption.OnlyErrorDialogs);
         }
+        #endregion
 
         // 谱面
         var oldMusicDir = Path.GetDirectoryName(music.FilePath)!;

--- a/MaiChartManager/Controllers/Tools/ImageToAbToolController.cs
+++ b/MaiChartManager/Controllers/Tools/ImageToAbToolController.cs
@@ -6,7 +6,7 @@ namespace MaiChartManager.Controllers.Tools;
 
 [ApiController]
 [Route("MaiChartManagerServlet/[action]Api")]
-public partial class ImageToAbToolController(ILogger<ImageToAbToolController> logger) : ControllerBase
+public partial class ImageToAbToolController(StaticSettings settings, ILogger<ImageToAbToolController> logger) : ControllerBase
 {
     [GeneratedRegex(@"^(?<id>\d+)\.(png|jpg|jpeg)$", RegexOptions.IgnoreCase)]
     private static partial Regex NumericFileRegex();
@@ -44,6 +44,17 @@ public partial class ImageToAbToolController(ILogger<ImageToAbToolController> lo
             await WriteEvent(ImageToAbEventType.Error, Locale.FileNotSelected);
             return;
         }
+        
+        // 所选择的路径是否是正规的OPT内jacket路径。方法是判断路径结尾是否是AssetBundleImages\jacket
+        var isIngameJacketPath = selectedPath.TrimEnd('\\').EndsWith(@"AssetBundleImages\jacket");
+
+        var deleteOriginalPngAfterSuccess = false;
+        if (isIngameJacketPath)
+        {
+            deleteOriginalPngAfterSuccess = MessageBox.Show(
+                Locale.ImageToAbDeleteOriginalPngQuestion, Locale.ImageToAb, MessageBoxButtons.YesNo, 
+                MessageBoxIcon.Question) == DialogResult.Yes;
+        }
 
         var candidates = Directory.EnumerateFiles(selectedPath)
             .Select(path => new
@@ -79,8 +90,9 @@ public partial class ImageToAbToolController(ILogger<ImageToAbToolController> lo
             return;
         }
 
-        var jacketDir = Path.Combine(selectedPath, "jacket");
-        var jacketSmallDir = Path.Combine(selectedPath, "jacket_s");
+        var outputRootDir = isIngameJacketPath ? Path.GetDirectoryName(selectedPath)! : selectedPath;
+        var jacketDir = Path.Combine(outputRootDir, "jacket");
+        var jacketSmallDir = Path.Combine(outputRootDir, "jacket_s");
         Directory.CreateDirectory(jacketDir);
         Directory.CreateDirectory(jacketSmallDir);
 
@@ -119,8 +131,22 @@ public partial class ImageToAbToolController(ILogger<ImageToAbToolController> lo
             {
                 logger.LogError(ex, "Failed to create AB for image {ImagePath}", item.FilePath);
                 failures.Add($"{Path.GetFileName(item.FilePath)}: {ex.Message}");
+                continue;
+            }
+            if (deleteOriginalPngAfterSuccess)
+            {
+                try
+                { // 删除原始文件。如果删除失败，也不要抛异常，只是打个警告
+                    System.IO.File.Delete(item.FilePath);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "Failed to delete source PNG after ImageToAb: {Path}", item.FilePath);
+                }
             }
         }
+        
+        await settings.RescanAll(); // rescan all
 
         if (failures.Count > 0)
         {

--- a/MaiChartManager/Controllers/Tools/ImageToAbToolController.cs
+++ b/MaiChartManager/Controllers/Tools/ImageToAbToolController.cs
@@ -46,7 +46,7 @@ public partial class ImageToAbToolController(StaticSettings settings, ILogger<Im
         }
         
         // 所选择的路径是否是正规的OPT内jacket路径。方法是判断路径结尾是否是AssetBundleImages\jacket
-        var isIngameJacketPath = selectedPath.TrimEnd('\\').EndsWith(@"AssetBundleImages\jacket");
+        var isIngameJacketPath = selectedPath.TrimEnd('\\').EndsWith(@"AssetBundleImages\jacket", StringComparison.OrdinalIgnoreCase);
 
         var deleteOriginalPngAfterSuccess = false;
         if (isIngameJacketPath)

--- a/MaiChartManager/Controllers/Tools/ImageToAbToolController.cs
+++ b/MaiChartManager/Controllers/Tools/ImageToAbToolController.cs
@@ -67,13 +67,13 @@ public partial class ImageToAbToolController(StaticSettings settings, ILogger<Im
                 var numericMatch = NumericFileRegex().Match(x.Name);
                 if (numericMatch.Success)
                 {
-                    return new ImageTaskItem(x.Path, numericMatch.Groups["id"].Value);
+                    return new ImageTaskItem(x.Path, int.Parse(numericMatch.Groups["id"].Value).ToString("000000"));
                 }
 
                 var uiJacketMatch = UiJacketFileRegex().Match(x.Name);
                 if (uiJacketMatch.Success)
                 {
-                    return new ImageTaskItem(x.Path, uiJacketMatch.Groups["id"].Value);
+                    return new ImageTaskItem(x.Path, int.Parse(uiJacketMatch.Groups["id"].Value).ToString("000000"));
                 }
 
                 return null;

--- a/MaiChartManager/Controllers/Tools/ImageToAbToolController.cs
+++ b/MaiChartManager/Controllers/Tools/ImageToAbToolController.cs
@@ -67,7 +67,7 @@ public partial class ImageToAbToolController(StaticSettings settings, ILogger<Im
                 var numericMatch = NumericFileRegex().Match(x.Name);
                 if (numericMatch.Success)
                 {
-                    return new ImageTaskItem(x.Path, int.Parse(numericMatch.Groups["id"].Value).ToString("000000"));
+                    return new ImageTaskItem(x.Path, numericMatch.Groups["id"].Value.PadLeft(6, '0'));
                 }
 
                 var uiJacketMatch = UiJacketFileRegex().Match(x.Name);

--- a/MaiChartManager/Controllers/Tools/ImageToAbToolController.cs
+++ b/MaiChartManager/Controllers/Tools/ImageToAbToolController.cs
@@ -73,7 +73,7 @@ public partial class ImageToAbToolController(StaticSettings settings, ILogger<Im
                 var uiJacketMatch = UiJacketFileRegex().Match(x.Name);
                 if (uiJacketMatch.Success)
                 {
-                    return new ImageTaskItem(x.Path, int.Parse(uiJacketMatch.Groups["id"].Value).ToString("000000"));
+                    return new ImageTaskItem(x.Path, uiJacketMatch.Groups["id"].Value.PadLeft(6, '0'));
                 }
 
                 return null;

--- a/MaiChartManager/Front/src/client/apiGen.ts
+++ b/MaiChartManager/Front/src/client/apiGen.ts
@@ -403,6 +403,7 @@ export interface SettingsDto {
   ignoreLevel?: boolean;
   disableBga?: boolean;
   useLegacyMaiLib?: boolean;
+  convertJacketToAssetBundle?: boolean;
   /** @format int32 */
   uiZoom?: number;
   /** @format double */

--- a/MaiChartManager/Front/src/locales/en.yaml
+++ b/MaiChartManager/Front/src/locales/en.yaml
@@ -618,6 +618,7 @@ settings:
   yuv420p: Use YUV420P color space when converting USM
   noScale: Don't scale video to 1080 width
   useLegacyMaiLib: Use legacy chart converter for import/export (compatibility mode)
+  convertJacketToAssetBundle: Use native AssetBundle format for music jackets
   updateChannel: Update Channel
   updateChannelSlow: Stable
   updateChannelCi: Fast

--- a/MaiChartManager/Front/src/locales/zh-TW.yaml
+++ b/MaiChartManager/Front/src/locales/zh-TW.yaml
@@ -579,6 +579,7 @@ settings:
   yuv420p: 轉換 USM 時使用 YUV420P 顏色空間
   noScale: 不要縮放影片到 1080 寬度
   useLegacyMaiLib: 匯入/匯出時，使用舊版轉譜器進行轉譜（相容模式）
+  convertJacketToAssetBundle: 歌曲封面圖使用原生AssetBundle格式
   updateChannel: 更新通道
   updateChannelSlow: 穩定
   updateChannelCi: 快速

--- a/MaiChartManager/Front/src/locales/zh.yaml
+++ b/MaiChartManager/Front/src/locales/zh.yaml
@@ -573,6 +573,7 @@ settings:
   yuv420p: 转换 USM 时使用 YUV420P 颜色空间
   noScale: 不要缩放视频到 1080 宽度
   useLegacyMaiLib: 导入/导出时，使用旧版转谱器进行转谱（兼容模式）
+  convertJacketToAssetBundle: 歌曲封面图使用原生AssetBundle格式
   updateChannel: 更新通道
   updateChannelSlow: 稳定
   updateChannelCi: 快速

--- a/MaiChartManager/Front/src/views/Settings/ImportOptionsSection.tsx
+++ b/MaiChartManager/Front/src/views/Settings/ImportOptionsSection.tsx
@@ -29,6 +29,7 @@ export default defineComponent({
           </div>
           <CheckBox v-model:value={appSettings.value.yuv420p} onChange={onSettingChange}>{t('settings.yuv420p')}</CheckBox>
           <CheckBox v-model:value={appSettings.value.noScale} onChange={onSettingChange}>{t('settings.noScale')}</CheckBox>
+          <CheckBox v-model:value={appSettings.value.convertJacketToAssetBundle} onChange={onSettingChange}>{t('settings.convertJacketToAssetBundle')}</CheckBox>
           <CheckBox v-model:value={appSettings.value.useLegacyMaiLib} onChange={onSettingChange}>{t('settings.useLegacyMaiLib')}</CheckBox>
         </div>
       </div>

--- a/MaiChartManager/Locale.Designer.cs
+++ b/MaiChartManager/Locale.Designer.cs
@@ -496,6 +496,24 @@ namespace MaiChartManager {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Image to AssetBundle.
+        /// </summary>
+        internal static string ImageToAb {
+            get {
+                return ResourceManager.GetString("ImageToAb", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Delete the original PNG/JPG images? (Direct image loading takes priority over the AB; if you do not delete them, the game will still load these images directly instead of the ABs at runtime.).
+        /// </summary>
+        internal static string ImageToAbDeleteOriginalPngQuestion {
+            get {
+                return ResourceManager.GetString("ImageToAbDeleteOriginalPngQuestion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Will import the following difficulties: .
         /// </summary>
         internal static string ImportingDifficulties {

--- a/MaiChartManager/Locale.resx
+++ b/MaiChartManager/Locale.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <root>
     <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
@@ -286,6 +286,12 @@ If you notice any issues with the conversion result, you can try testing it in A
   </data>
     <data name="NoValidImagesFound" xml:space="preserve">
     <value>No valid images found (expected: numeric filename or ui_jacket_* pattern, PNG/JPG format)</value>
+  </data>
+  <data name="ImageToAbDeleteOriginalPngQuestion" xml:space="preserve">
+    <value>Delete the original PNG/JPG images? (Direct image loading takes priority over the AB; if you do not delete them, the game will still load these images directly instead of the ABs at runtime.)</value>
+  </data>
+  <data name="ImageToAb" xml:space="preserve">
+    <value>Image to AssetBundle</value>
   </data>
 
     <!-- ModController -->

--- a/MaiChartManager/Locale.zh-hans.resx
+++ b/MaiChartManager/Locale.zh-hans.resx
@@ -279,6 +279,12 @@
     <data name="NoValidImagesFound" xml:space="preserve">
     <value>未找到有效的图片文件（需要：纯数字文件名或 ui_jacket_* 格式，PNG/JPG 格式）</value>
   </data>
+  <data name="ImageToAbDeleteOriginalPngQuestion" xml:space="preserve">
+    <value>是否需要删除原有的PNG/JPG图片？（由于直读优先级高于AB，如果不删除的话，则游戏运行时还是会优先进行图片直读。）</value>
+  </data>
+  <data name="ImageToAb" xml:space="preserve">
+    <value>图片转 AssetBundle</value>
+  </data>
 
     <!-- ModController -->
     <data name="UnsupportedConfigVersion" xml:space="preserve">

--- a/MaiChartManager/Locale.zh-hant.resx
+++ b/MaiChartManager/Locale.zh-hant.resx
@@ -1,4 +1,4 @@
-﻿<root>
+<root>
     <resheader name="resmimetype">
         <value>text/microsoft-resx</value>
     </resheader>
@@ -278,6 +278,12 @@
   </data>
     <data name="NoValidImagesFound" xml:space="preserve">
     <value>未找到有效的圖片檔案（需要：純數字檔名或 ui_jacket_* 格式，PNG/JPG 格式）</value>
+  </data>
+  <data name="ImageToAbDeleteOriginalPngQuestion" xml:space="preserve">
+    <value>是否需要刪除原有的 PNG/JPG 圖片？（由於直讀優先級高於 AB，若不刪除的話，則遊戲執行時還是會優先進行圖片直讀。）</value>
+  </data>
+  <data name="ImageToAb" xml:space="preserve">
+    <value>圖片轉 AssetBundle</value>
   </data>
 
     <!-- ModController -->

--- a/MaiChartManager/Models/MusicXml.cs
+++ b/MaiChartManager/Models/MusicXml.cs
@@ -566,7 +566,7 @@ public partial class MusicXml
 
     public static readonly string[] jacketExtensions = ["jpg", "png", "jpeg"];
 
-    [JsonIgnore] public string JacketPath { get; set; }
+    [JsonIgnore] public string? JacketPath { get; set; }
 
     public bool HasJacket => JacketPath is not null;
 

--- a/MaiChartManager/Models/MusicXmlWithABJacket.cs
+++ b/MaiChartManager/Models/MusicXmlWithABJacket.cs
@@ -11,7 +11,7 @@ public class MusicXmlWithABJacket(string filePath, string gamePath, string asset
 
     // 在 mod 里文件的 jacket 是优先的
     public new bool HasJacket => JacketPath is not null || AssetBundleJacket is not null || PseudoAssetBundleJacket is not null;
-    public string RealJacketPath => JacketPath ?? PseudoAssetBundleJacket ?? AssetBundleJacket;
+    public string? RealJacketPath => JacketPath ?? PseudoAssetBundleJacket ?? AssetBundleJacket;
 
     public new static MusicXmlWithABJacket CreateNew(int id, string gamePath, string assetDir)
     {
@@ -139,7 +139,7 @@ public class MusicXmlWithABJacket(string filePath, string gamePath, string asset
             Console.WriteLine($"删除 jacket 失败: {RealJacketPath}");
             return false;
         }
-        JacketPath = null!;
+        JacketPath = null;
         StaticSettings.AssetBundleJacketMap.Remove(NonDxId);
         StaticSettings.PseudoAssetBundleJacketMap.Remove(NonDxId);
 

--- a/MaiChartManager/Models/MusicXmlWithABJacket.cs
+++ b/MaiChartManager/Models/MusicXmlWithABJacket.cs
@@ -121,48 +121,57 @@ public class MusicXmlWithABJacket(string filePath, string gamePath, string asset
         }
     }
 
-    public void Delete()
+    internal bool DeleteJacket()
     {
-        if (HasJacket && RealJacketPath?.Contains(@"\A000\", StringComparison.InvariantCultureIgnoreCase) == false)
+        bool sholdDelete = HasJacket && RealJacketPath?.Contains(@"\A000\", StringComparison.InvariantCultureIgnoreCase) == false;
+        if (!sholdDelete) return false;
+        
+        Console.WriteLine("删除 jacket: " + RealJacketPath);
+        try
+        { 
+            FileSystem.DeleteFile(RealJacketPath);
+            if (RealJacketPath.EndsWith(".ab")) // .ab的情况，要额外把manifest也干掉
+                FileSystem.DeleteFile(RealJacketPath + ".manifest");
+        }
+        catch
         {
-            Console.WriteLine("删除 jacket: " + RealJacketPath);
-            try
-            {
-                FileSystem.DeleteFile(RealJacketPath);
-                if (RealJacketPath.EndsWith(".ab")) // .ab的情况，要额外把manifest也干掉
-                    FileSystem.DeleteFile(RealJacketPath + ".manifest");
-            }
-            catch
-            {
-                Console.WriteLine($"删除 jacket 失败: {RealJacketPath}");
-            }
+            Console.WriteLine($"删除 jacket 失败: {RealJacketPath}");
+        }
+        JacketPath = null!;
+        StaticSettings.AssetBundleJacketMap.Remove(NonDxId);
+        StaticSettings.PseudoAssetBundleJacketMap.Remove(NonDxId);
 
-            // Issue #42: AB jackets come with a companion jacket_s/ui_jacket_xxx_s.ab, delete it too to avoid orphan
-            if (AssetBundleJacket is not null)
+        // Issue #42: AB jackets come with a companion jacket_s/ui_jacket_xxx_s.ab, delete it too to avoid orphan
+        if (AssetBundleJacket is not null)
+        {
+            var abDir = Path.GetDirectoryName(AssetBundleJacket);
+            var parentDir = string.IsNullOrWhiteSpace(abDir) ? null : Path.GetDirectoryName(abDir);
+            if (!string.IsNullOrWhiteSpace(parentDir))
             {
-                var abDir = Path.GetDirectoryName(AssetBundleJacket);
-                var parentDir = string.IsNullOrWhiteSpace(abDir) ? null : Path.GetDirectoryName(abDir);
-                if (!string.IsNullOrWhiteSpace(parentDir))
+                var jacketSPath = Path.Combine(parentDir, "jacket_s",
+                    Path.GetFileNameWithoutExtension(AssetBundleJacket) + "_s" + Path.GetExtension(AssetBundleJacket));
+                if (File.Exists(jacketSPath) && !jacketSPath.Contains(@"\A000\", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    var jacketSPath = Path.Combine(parentDir, "jacket_s",
-                        Path.GetFileNameWithoutExtension(AssetBundleJacket) + "_s" + Path.GetExtension(AssetBundleJacket));
-                    if (File.Exists(jacketSPath) && !jacketSPath.Contains(@"\A000\", StringComparison.InvariantCultureIgnoreCase))
+                    Console.WriteLine("删除 jacket_s: " + jacketSPath);
+                    try
                     {
-                        Console.WriteLine("删除 jacket_s: " + jacketSPath);
-                        try
-                        {
-                            FileSystem.DeleteFile(jacketSPath);
-                            if (File.Exists(jacketSPath + ".manifest"))
-                                FileSystem.DeleteFile(jacketSPath + ".manifest");
-                        }
-                        catch
-                        {
-                            Console.WriteLine($"删除 jacket_s 失败: {jacketSPath}");
-                        }
+                        FileSystem.DeleteFile(jacketSPath);
+                        if (File.Exists(jacketSPath + ".manifest"))
+                            FileSystem.DeleteFile(jacketSPath + ".manifest");
+                    }
+                    catch
+                    {
+                        Console.WriteLine($"删除 jacket_s 失败: {jacketSPath}");
                     }
                 }
             }
         }
+        return true;
+    }
+    
+    public void Delete()
+    {
+        DeleteJacket();
 
         if (StaticSettings.AcbAwb.TryGetValue($"music{NonDxId:000000}.acb", out var acb) && acb?.Contains(@"\A000\", StringComparison.InvariantCultureIgnoreCase) == false)
         {

--- a/MaiChartManager/Models/MusicXmlWithABJacket.cs
+++ b/MaiChartManager/Models/MusicXmlWithABJacket.cs
@@ -123,33 +123,35 @@ public class MusicXmlWithABJacket(string filePath, string gamePath, string asset
 
     internal bool DeleteJacket()
     {
-        bool sholdDelete = HasJacket && RealJacketPath?.Contains(@"\A000\", StringComparison.InvariantCultureIgnoreCase) == false;
-        if (!sholdDelete) return false;
+        bool shouldDelete = HasJacket && RealJacketPath?.Contains(@"\A000\", StringComparison.InvariantCultureIgnoreCase) == false;
+        if (!shouldDelete) return false;
+        var assetBundleJacket = this.AssetBundleJacket;
         
         Console.WriteLine("删除 jacket: " + RealJacketPath);
         try
         { 
             FileSystem.DeleteFile(RealJacketPath);
-            if (RealJacketPath.EndsWith(".ab")) // .ab的情况，要额外把manifest也干掉
+            if (RealJacketPath.EndsWith(".ab") && File.Exists(RealJacketPath + ".manifest")) // .ab的情况，要额外把manifest也干掉
                 FileSystem.DeleteFile(RealJacketPath + ".manifest");
         }
         catch
         {
             Console.WriteLine($"删除 jacket 失败: {RealJacketPath}");
+            return false;
         }
         JacketPath = null!;
         StaticSettings.AssetBundleJacketMap.Remove(NonDxId);
         StaticSettings.PseudoAssetBundleJacketMap.Remove(NonDxId);
 
         // Issue #42: AB jackets come with a companion jacket_s/ui_jacket_xxx_s.ab, delete it too to avoid orphan
-        if (AssetBundleJacket is not null)
+        if (assetBundleJacket is not null)
         {
-            var abDir = Path.GetDirectoryName(AssetBundleJacket);
+            var abDir = Path.GetDirectoryName(assetBundleJacket);
             var parentDir = string.IsNullOrWhiteSpace(abDir) ? null : Path.GetDirectoryName(abDir);
             if (!string.IsNullOrWhiteSpace(parentDir))
             {
                 var jacketSPath = Path.Combine(parentDir, "jacket_s",
-                    Path.GetFileNameWithoutExtension(AssetBundleJacket) + "_s" + Path.GetExtension(AssetBundleJacket));
+                    Path.GetFileNameWithoutExtension(assetBundleJacket) + "_s" + Path.GetExtension(assetBundleJacket));
                 if (File.Exists(jacketSPath) && !jacketSPath.Contains(@"\A000\", StringComparison.InvariantCultureIgnoreCase))
                 {
                     Console.WriteLine("删除 jacket_s: " + jacketSPath);

--- a/MaiChartManager/Utils/AssetBundleCreator.cs
+++ b/MaiChartManager/Utils/AssetBundleCreator.cs
@@ -156,6 +156,34 @@ public static class AssetBundleCreator
         newBundle.Pack(new AssetsFileWriter(outStream), AssetBundleCompressionType.LZ4, false, null);
     }
     
+    public static string CreateMusicJacketAssetBundles(ReadOnlySpan<byte> pngImageData, string AssetBundleImagesDir, int musicId)
+    {
+        var abiDir = Path.Combine(AssetBundleImagesDir, "jacket");
+        var abiSDir = Path.Combine(AssetBundleImagesDir, "jacket_s");
+        Directory.CreateDirectory(abiDir);
+        Directory.CreateDirectory(abiSDir);
+        
+        string key = $"ui_jacket_{musicId:000000}";
+        
+        CreateTextureAssetBundle(
+            pngImageData,
+            Path.Combine(abiDir, $"{key}.ab"),
+            key,
+            $"assets/assetbundle/jacket/{key}.png",
+            $"jacket/{key}.ab");
+
+        CreateTextureAssetBundle(
+            pngImageData,
+            Path.Combine(abiSDir, $"{key}_s.ab"),
+            $"{key}_s",
+            $"assets/assetbundle/jacket_s/{key}_s.png",
+            $"jacket_s/{key}_s.ab",
+            resizeWidth: 200,
+            resizeHeight: 200);
+
+        return Path.Combine(abiDir, $"{key}.ab");
+    }
+    
     // 读取输入的ab包当中的图片，然后用指定的assetName等参数重新打包。
     // 适用于歌曲改ID等的场景。
     public static void RepackTextureAssetBundle(

--- a/MaiChartManager/Utils/AssetBundleCreator.cs
+++ b/MaiChartManager/Utils/AssetBundleCreator.cs
@@ -26,30 +26,47 @@ public static class AssetBundleCreator
     {
         if (!File.Exists(imagePath))
             throw new FileNotFoundException($"Image file not found: {imagePath}", imagePath);
+        CreateTextureAssetBundle(File.ReadAllBytes(imagePath), outputAbPath, assetName, containerPath, abName, resizeWidth, resizeHeight);
+    }
 
+    public static void CreateTextureAssetBundle(
+        ReadOnlySpan<byte> pngImageData,
+        string outputAbPath,
+        string assetName,
+        string containerPath,
+        string abName,
+        int? resizeWidth = null,
+        int? resizeHeight = null)
+    {
+        using var image = SixLabors.ImageSharp.Image.Load<Rgba32>(pngImageData);
+        if (resizeWidth.HasValue && resizeHeight.HasValue)
+            image.Mutate(x => x.Resize(resizeWidth.Value, resizeHeight.Value));
+
+        image.Mutate(x => x.Flip(FlipMode.Vertical));
+
+        int width = image.Width;
+        int height = image.Height;
+        var rgbaData = new byte[width * height * 4];
+        image.CopyPixelDataTo(rgbaData);
+        
+        CreateTextureAssetBundle(rgbaData, width, height, outputAbPath, assetName, containerPath, abName);
+    }
+
+    private static void CreateTextureAssetBundle(
+        byte[] rgbaData,
+        int width,
+        int height,
+        string outputAbPath,
+        string assetName,
+        string containerPath,
+        string abName)
+    {
         if (!File.Exists(TemplateAbPath))
             throw new FileNotFoundException($"Template AB not found: {TemplateAbPath}", TemplateAbPath);
 
         var outputDir = Path.GetDirectoryName(outputAbPath);
         if (!string.IsNullOrWhiteSpace(outputDir))
             Directory.CreateDirectory(outputDir);
-
-        // 加载图片并转为 RGBA32 像素数据
-        byte[] rgbaData;
-        int width, height;
-
-        using (var image = SixLabors.ImageSharp.Image.Load<Rgba32>(imagePath))
-        {
-            if (resizeWidth.HasValue && resizeHeight.HasValue)
-                image.Mutate(x => x.Resize(resizeWidth.Value, resizeHeight.Value));
-
-            image.Mutate(x => x.Flip(FlipMode.Vertical));
-
-            width = image.Width;
-            height = image.Height;
-            rgbaData = new byte[width * height * 4];
-            image.CopyPixelDataTo(rgbaData);
-        }
 
         // 加载模板 AB 并解包
         var am = new AssetsManager();
@@ -137,6 +154,24 @@ public static class AssetBundleCreator
 
         using var outStream = File.Create(outputAbPath);
         newBundle.Pack(new AssetsFileWriter(outStream), AssetBundleCompressionType.LZ4, false, null);
+    }
+    
+    // 读取输入的ab包当中的图片，然后用指定的assetName等参数重新打包。
+    // 适用于歌曲改ID等的场景。
+    public static void RepackTextureAssetBundle(
+        string inputAbPath,
+        string outputAbPath,
+        string assetName,
+        string containerPath,
+        string abName)
+    {
+        if (!File.Exists(inputAbPath))
+            throw new FileNotFoundException($"Input AB not found: {inputAbPath}", inputAbPath);
+
+        var pngBytes = ImageConvert.GetTextureAsPngData(inputAbPath);
+        if (pngBytes is null || pngBytes.Length == 0)
+            throw new InvalidOperationException($"Could not decode jacket texture to PNG from: {inputAbPath}");
+        CreateTextureAssetBundle(pngBytes, outputAbPath, assetName, containerPath, abName);
     }
 
     private static void WriteUncompressedBundle(byte[] assetsData, string cabName, Stream output)

--- a/MaiChartManager/Utils/AssetBundleCreator.cs
+++ b/MaiChartManager/Utils/AssetBundleCreator.cs
@@ -163,7 +163,7 @@ public static class AssetBundleCreator
         Directory.CreateDirectory(abiDir);
         Directory.CreateDirectory(abiSDir);
         
-        string key = $"ui_jacket_{musicId:000000}";
+        string key = $"UI_Jacket_{musicId:000000}";
         
         CreateTextureAssetBundle(
             pngImageData,

--- a/MaiChartManager/Utils/AssetBundleCreator.cs
+++ b/MaiChartManager/Utils/AssetBundleCreator.cs
@@ -167,17 +167,17 @@ public static class AssetBundleCreator
         
         CreateTextureAssetBundle(
             pngImageData,
-            Path.Combine(abiDir, $"{key}.ab"),
+            Path.Combine(abiDir, $"{key.ToLowerInvariant()}.ab"),
             key,
-            $"assets/assetbundle/jacket/{key}.png",
-            $"jacket/{key}.ab");
+            $"assets/assetbundle/jacket/{key.ToLowerInvariant()}.png",
+            $"jacket/{key.ToLowerInvariant()}.ab");
 
         CreateTextureAssetBundle(
             pngImageData,
-            Path.Combine(abiSDir, $"{key}_s.ab"),
+            Path.Combine(abiSDir, $"{key.ToLowerInvariant()}_s.ab"),
             $"{key}_s",
-            $"assets/assetbundle/jacket_s/{key}_s.png",
-            $"jacket_s/{key}_s.ab",
+            $"assets/assetbundle/jacket_s/{key.ToLowerInvariant()}_s.png",
+            $"jacket_s/{key.ToLowerInvariant()}_s.ab",
             resizeWidth: 200,
             resizeHeight: 200);
 

--- a/MaiChartManager/Utils/ImageConvert.cs
+++ b/MaiChartManager/Utils/ImageConvert.cs
@@ -1,4 +1,4 @@
-﻿using AssetStudio;
+using AssetStudio;
 using MaiChartManager.Models;
 
 namespace MaiChartManager.Utils;
@@ -23,9 +23,13 @@ public static class ImageConvert
         }
 
         if (music.AssetBundleJacket is null) return null;
+        return GetTextureAsPngData(music.AssetBundleJacket);
+    }
 
+    public static byte[]? GetTextureAsPngData(string inputAbPath)
+    {
         var manager = new AssetsManager();
-        manager.LoadFiles(music.AssetBundleJacket);
+        manager.LoadFiles(inputAbPath);
         var asset = manager.assetsFileList[0].Objects.Find(it => it.type == ClassIDType.Texture2D);
         if (asset is null) return null;
 

--- a/MaiChartManager/Utils/ImageConvert.cs
+++ b/MaiChartManager/Utils/ImageConvert.cs
@@ -34,6 +34,7 @@ public static class ImageConvert
         if (asset is null) return null;
 
         var texture = asset as Texture2D;
-        return texture.ConvertToStream(ImageFormat.Png, true).GetBuffer();
+        using var stream = texture.ConvertToStream(ImageFormat.Png, true);
+        return stream.ToArray();
     }
 }


### PR DESCRIPTION
1. 引入新的配置项：ConvertJacketToAssetBundle，默认开启，行为是会在导入歌曲时自动把图片打包为AssetBundle，以取代原来的直读，解决png直读性能较差的问题。
2. ModifyIdApi，对于已经是AssetBundle的歌曲，会重新打包AssetBundle、修改其内的musicId，以保证程序还能正确读取。
3. 优化ImageToAbTool的行为，便于已经有了很多PNG直读封面的自制谱的老用户，更方便地将PNG封面转换为ab。

已在个人电脑上测试通过（导入谱面+修改ID+批量转换）

## Summary by Sourcery

将谱面封面（music jacket）的处理方式转换为默认可选使用基于 AssetBundle 的图片，并改进相关工具和删除逻辑。

New Features:
- 新增可配置的 `ConvertJacketToAssetBundle` 选项，用于控制导入的谱面封面是否默认转换为 AssetBundle。
- 在设置谱面封面时，直接从上传的图片数据生成大封面和小封面的 AssetBundle。
- 提供可复用的 API，用于从图片数据创建谱面封面 AssetBundle，以及用新 ID 重新打包已有纹理 AssetBundle。

Bug Fixes:
- 确保在移除或替换封面时，封面和对应的 `jacket_s` AssetBundle 及其 manifest 能被一致地删除。
- 修复基于 AssetBundle 的封面在 `ModifyId` 操作下的行为，通过为新 ID 重新打包或重新生成封面 AssetBundle，并清理旧的 bundle。

Enhancements:
- 重构纹理 AssetBundle 的创建逻辑，以支持原始 PNG 字节数据并共享逻辑，从而可被多项功能复用。
- 改进 `ImageToAb` 工具的用户体验，允许在游戏封面目录中就地转换，可选删除原始 PNG，并在转换后重新扫描资源。
- 更新设置 DTO、配置和前端，在 UI 中暴露新的封面 AssetBundle 转换选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Convert music jacket handling to optionally use AssetBundle-based images by default and improve related tools and deletion logic.

New Features:
- Add a configurable ConvertJacketToAssetBundle option that controls whether imported music jackets are converted to AssetBundles by default.
- Generate main and small jacket AssetBundles directly from uploaded image data when setting music jackets.
- Provide a reusable API to create music jacket AssetBundles from image data and to repack existing texture AssetBundles with new IDs.

Bug Fixes:
- Ensure jacket and companion jacket_s AssetBundles and their manifests are consistently deleted when removing or replacing jackets.
- Fix ModifyId behavior for AssetBundle-based jackets by repacking or regenerating jacket AssetBundles for the new ID and cleaning up old bundles.

Enhancements:
- Refactor texture AssetBundle creation to support raw PNG bytes and shared logic, enabling reuse by multiple features.
- Improve ImageToAb tool UX by allowing conversion in-place in the in-game jacket directory, optionally deleting original PNGs, and rescanning assets after conversion.
- Update settings DTO, config, and frontend to expose the new jacket AssetBundle conversion option in the UI.

</details>

## Summary by Sourcery

在导入和修改 ID 时，为音乐封面新增可选的基于 AssetBundle 的处理方式，并简化相关工具和设置。

New Features:
- 引入可配置的 `ConvertJacketToAssetBundle` 设置，用于控制是否在导入音乐封面时自动将其转换为 AssetBundle。
- 在设置音乐封面时，直接从上传的图像数据生成主封面和小封面的 AssetBundle。
- 提供可复用的辅助方法，用于从 PNG 数据创建和重新打包纹理 AssetBundle，包括音乐封面相关的 AssetBundle。

Bug Fixes:
- 在删除封面时，确保从磁盘和内部映射中一致地移除封面及其对应的 `jacket_s` AssetBundle 以及它们的 manifest。
- 修复对基于 AssetBundle 的封面执行 `ModifyId` 时的处理逻辑，通过为新 ID 重新打包或重新生成封面 AssetBundle，并清理旧的 Bundle 和 manifest。

Enhancements:
- 重构纹理 AssetBundle 的创建逻辑，使其可以接受原始图像字节数据，并在多个功能之间共享这部分逻辑。
- 改进 ImageToAb 工具，使其支持在游戏内封面目录中就地转换，支持可选删除原始 PNG，并在转换后重新扫描资源。
- 更新设置 DTO、配置和前端，在 UI 中暴露新的封面 AssetBundle 转换选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add optional AssetBundle-based handling for music jackets during import and ID modification, and streamline related tools and settings.

New Features:
- Introduce a configurable ConvertJacketToAssetBundle setting to control automatic conversion of imported music jackets into AssetBundles.
- Generate main and small jacket AssetBundles directly from uploaded image data when setting music jackets.
- Provide reusable helpers to create and repack texture AssetBundles, including music jacket bundles, from PNG data.

Bug Fixes:
- Ensure jacket and companion jacket_s AssetBundles and their manifests are consistently removed from disk and internal maps when deleting jackets.
- Fix ModifyId handling for AssetBundle-based jackets by repacking or regenerating jacket AssetBundles for the new ID and cleaning up old bundles and manifests.

Enhancements:
- Refactor texture AssetBundle creation to accept raw image bytes and share logic across features.
- Improve the ImageToAb tool to support in-place conversion in the in-game jacket directory, optionally delete original PNGs, and rescan assets after conversion.
- Update settings DTO, config, and frontend to expose the new jacket AssetBundle conversion option in the UI.

</details>