### PR TITLE
fix: ModifyId，假如新ID和旧ID的NonDX相同（例如5003->15003），会导致源文件被误删除且发生报错。

### DIFF
--- a/MaiChartManager/Controllers/Music/MusicTransferController.cs
+++ b/MaiChartManager/Controllers/Music/MusicTransferController.cs
@@ -513,21 +513,12 @@ public partial class MusicTransferController(StaticSettings settings, ILogger<Mu
             FileSystem.DeleteFile(abPath + ".manifest", UIOption.OnlyErrorDialogs, RecycleOption.SendToRecycleBin);
     }
 
-    [HttpPost]
-    public async Task ModifyId(int id, [FromBody] int newId, string assetDir)
+    private void MoveJacketSoundVideo(MusicXmlWithABJacket music, int newId, string assetDir)
     {
-        if (IapManager.License != IapManager.LicenseStatus.Active) return;
-        var music = settings.GetMusic(id, assetDir);
-        if (music is null) return;
-        var musicDir = Path.GetDirectoryName(music.FilePath);
-        if (string.IsNullOrWhiteSpace(musicDir) || !Directory.Exists(musicDir))
-        {
-            var message = $"Invalid source directory for music {music.Id}: {music.FilePath}";
-            logger.LogError("{message}", message);
-            throw new DirectoryNotFoundException(message);
-        }
         var newNonDxId = newId % 10000;
-
+        // 当新ID和旧ID的 NonDx部分相同时（例如 5003 -> 15003），封面、音频、视频文件的目标路径与源路径完全一致，因此既不需要也不应该删除/移动它们。
+        if (newNonDxId == music.NonDxId) return;
+        
         var abiDir = Path.Combine(StaticSettings.StreamingAssets, assetDir, @"AssetBundleImages\jacket");
         var abiSDir = Path.Combine(StaticSettings.StreamingAssets, assetDir, @"AssetBundleImages\jacket_s");
         Directory.CreateDirectory(abiDir);
@@ -536,8 +527,7 @@ public partial class MusicTransferController(StaticSettings settings, ILogger<Mu
         var abJacketSTarget = Path.Combine(abiSDir, $"ui_jacket_{newNonDxId:000000}_s.ab");
         var acbawbTarget = Path.Combine(StaticSettings.StreamingAssets, assetDir, "SoundData", $"music{newNonDxId:000000}");
         var movieTarget = Path.Combine(StaticSettings.StreamingAssets, assetDir, "MovieData", $"{newNonDxId:000000}");
-        var newMusicDir = Path.Combine(StaticSettings.StreamingAssets, assetDir, "music", $"music{newId:000000}");
-        DeleteIfExists(abJacketTarget, abJacketTarget + ".manifest", abJacketSTarget, abJacketSTarget + ".manifest", acbawbTarget + ".acb", acbawbTarget + ".awb", movieTarget + ".dat", movieTarget + ".mp4", newMusicDir);
+        DeleteIfExists(abJacketTarget, abJacketTarget + ".manifest", abJacketSTarget, abJacketSTarget + ".manifest", acbawbTarget + ".acb", acbawbTarget + ".awb", movieTarget + ".dat", movieTarget + ".mp4");
 
         #region 移动或重打包封面图
         var jacketSourcePath = music.JacketPath is not null ? music.JacketPath : music.PseudoAssetBundleJacket;
@@ -617,6 +607,27 @@ public partial class MusicTransferController(StaticSettings settings, ILogger<Mu
             FileSystem.MoveFile(movie, movieTarget + Path.GetExtension(movie), UIOption.OnlyErrorDialogs);
         }
         #endregion
+    }
+    
+    [HttpPost]
+    public async Task ModifyId(int id, [FromBody] int newId, string assetDir)
+    {
+        if (IapManager.License != IapManager.LicenseStatus.Active) return;
+        var music = settings.GetMusic(id, assetDir);
+        if (music is null) return;
+        var musicDir = Path.GetDirectoryName(music.FilePath);
+        if (string.IsNullOrWhiteSpace(musicDir) || !Directory.Exists(musicDir))
+        {
+            var message = $"Invalid source directory for music {music.Id}: {music.FilePath}";
+            logger.LogError("{message}", message);
+            throw new DirectoryNotFoundException(message);
+        }
+        if (music.Id == newId) return;
+        
+        var newMusicDir = Path.Combine(StaticSettings.StreamingAssets, assetDir, "music", $"music{newId:000000}");
+        DeleteIfExists(newMusicDir);
+
+        MoveJacketSoundVideo(music, newId, assetDir); // 移动封面图、音频、视频
 
         // 谱面
         var oldMusicDir = Path.GetDirectoryName(music.FilePath)!;


### PR DESCRIPTION
如题，ModifyId，假如新ID和旧ID的NonDX相同（例如5003->15003），会导致源文件被误删除且发生报错。

之前的逻辑会计算新ID下文件移动到的目标路径，如果已经存在冲突的同名文件文件则删除之，再尝试移动旧ID下的文件过来。
那么当5003->15003时，目标计算出的还是`ui_jacket_005003.jpg`，于是这个“如果已经存在冲突的同名文件文件则删除之”的过程直接把源文件干掉了。

根据OPT中文件的排列规则，封面图、音频、视频用的都是nonDX四位ID，只有谱面`music`目录下用的六位长ID。所以当上述“新ID和旧ID的NonDX相同”的情况下，封面图、音频、视频根本不需要做任何移动。
所以把移动封面图、音频、视频的过程单独抽成一个函数，如果新ID和旧ID的NonDX相同则直接return、跳过移动它们的过程。谱面music则仍是每次正常移动。

## Summary by Sourcery

通过将封面 / 音频 / 视频 的处理与谱面数据迁移分离，防止在新 ID 与旧 ID 具有相同非 DX 部分时，`ModifyId` 误删、误移动媒体文件。

Bug Fixes:
- 在新旧 ID 具有相同非 DX 组成部分的 ID 变更过程中，避免误删源封面、音频和视频文件。

Enhancements:
- 将媒体文件（封面 / 音频 / 视频）的迁移逻辑提取到一个由 `ModifyId` 调用的专用辅助方法中，从而与谱面文件处理实现更清晰的职责分离。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent ModifyId from incorrectly deleting and moving media files when the new ID shares the same non-DX portion as the old ID by separating jacket/audio/video handling from chart data migration.

Bug Fixes:
- Avoid accidental deletion of source jacket, audio, and video files during ID changes where the new and old IDs have the same non-DX component.

Enhancements:
- Extract media (jacket/audio/video) migration into a dedicated helper method invoked from ModifyId for clearer separation from chart file handling.

</details>