### PR TITLE
fix: 当遇到物量为0的谱面时会抛异常，和优化生成levelId的逻辑

### DIFF
--- a/MaiChartManager/Controllers/Charts/ImportChartController.cs
+++ b/MaiChartManager/Controllers/Charts/ImportChartController.cs
@@ -134,7 +134,7 @@ public class ImportChartController(StaticSettings settings, ILogger<StaticSettin
                 }
             }
             
-            if (resultCharts.Count == 0) // 没有解析成功的谱面
+            if ((StaticSettings.Config.UseLegacyMaiLib ? legacyCharts.Count : resultCharts.Count) == 0) // 没有解析成功的谱面
             {
                 errors.Add(new ImportChartMessage(Locale.MusicNoCharts, MessageLevel.Fatal));
                 fatal = true;

--- a/MaiChartManager/Controllers/Charts/ImportChartController.cs
+++ b/MaiChartManager/Controllers/Charts/ImportChartController.cs
@@ -76,13 +76,6 @@ public class ImportChartController(StaticSettings settings, ILogger<StaticSettin
             }
             # endregion
 
-            if (targetLevelMap.Count == 0) // 没有能够被映射的谱面
-            {
-                errors.Add(new ImportChartMessage(Locale.MusicNoCharts, MessageLevel.Fatal));
-                fatal = true;
-                return new ImportChartCheckResult(!fatal, errors, new Dictionary<ShiftMethod, float>(), false, title, 0, null);
-            }
-
             var first = maiData.First;
             var isDx = false;
             List<MaiChart> resultCharts = [];
@@ -118,8 +111,13 @@ public class ImportChartController(StaticSettings settings, ILogger<StaticSettin
                 {
                     //                                                 ↓ 此处的参数应该不会影响 check 的结果
                     var (chart, alerts1) = new SimaiParser(false, maiData.ClockCount).Parse(data.Inote);
-                    resultCharts.Add(chart);
                     alerts.AddRange(alerts1);
+                    if (chart.TotalNotes == 0)
+                    {
+                        errors.Add(new ImportChartMessage(string.Format(Locale.ChartNoNotes, lv), MessageLevel.Warning));
+                        continue;
+                    }
+                    resultCharts.Add(chart);
                     var (_, alerts2) = new MA2Generator().Generate(chart);
                     alerts.AddRange(alerts2);
                     isDx = isDx || chart.IsDxChart;
@@ -134,6 +132,12 @@ public class ImportChartController(StaticSettings settings, ILogger<StaticSettin
                     var m = ImportChartMessage.FromAlert(alert, lv, lineNoDict);
                     if (m != null) errors.Add(m);
                 }
+            }
+            
+            if (resultCharts.Count == 0) // 没有解析成功的谱面
+            {
+                errors.Add(new ImportChartMessage(Locale.MusicNoCharts, MessageLevel.Fatal));
+                fatal = true;
             }
 
             Dictionary<ShiftMethod, float> chartPaddingsSec = new();

--- a/MaiChartManager/Controllers/Charts/Services/MaidataImportService.cs
+++ b/MaiChartManager/Controllers/Charts/Services/MaidataImportService.cs
@@ -185,11 +185,6 @@ public class MaidataImportService : IMaidataImportService
         var lineNoDict = GetLevelLineNo(maiDataText);
         
         var targetLevelMap = MapMaidataLevelToGame(maiData);
-        if (targetLevelMap.Count == 0) // 没有能够被映射的谱面
-        {
-            errors.Add(new ImportChartMessage(Locale.MusicNoCharts, MessageLevel.Fatal));
-            return new ImportChartResult(errors, true);
-        }
         
         // 先执行第一步：Parser，因为可能涉及对Chart做出调整
         List<(int lv, int targetLevel, MaidataLevel data, MaiChart? chart, List<Alert> alerts)> parserOutput = [];
@@ -219,7 +214,13 @@ public class MaidataImportService : IMaidataImportService
             }
         }
         
-        var chartPaddingDict = CalcChartPadding(parserOutput.Where(x=>x.chart != null).Select(x=>x.chart!).ToList());
+        var validCharts = parserOutput.Where(x=> x.chart != null).Select(x => x.chart!).ToList();
+        if (validCharts.Count == 0)
+        {
+            errors.Add(new ImportChartMessage(Locale.MusicNoCharts, MessageLevel.Fatal));
+            return new ImportChartResult(errors, true);
+        }
+        var chartPaddingDict = CalcChartPadding(validCharts);
         var chartPadding = chartPaddingDict[shift]; // 当前所选择的模式所具体对应的chartPadding
 
         foreach (var c in music.Charts) { c.Enable = false; } // 先把所有难度标记为关闭（马上后面"第二步"的逻辑，会对存在的难度打开）

--- a/MaiChartManager/Controllers/Charts/Services/MaidataImportService.cs
+++ b/MaiChartManager/Controllers/Charts/Services/MaidataImportService.cs
@@ -1,4 +1,4 @@
-﻿using MaiChartManager.Models;
+using MaiChartManager.Models;
 using MaiChartManager.Utils;
 using MuConvert.mai;
 using MuConvert.utils;
@@ -233,18 +233,8 @@ public class MaidataImportService : IMaidataImportService
             targetChart.Path = $"{id:000000}_0{targetLevel}.ma2";
             
             #region 计算等级（定数）相关
-            var levelNumStr = data.Level;
-            if (!string.IsNullOrWhiteSpace(levelNumStr))
-            {
-                if (isUtage && !char.IsDigit(levelNumStr[0]))
-                {
-                    music.UtageKanji = levelNumStr.Substring(0, 1);
-                    levelNumStr = levelNumStr.Substring(1).Replace("?", ""); // 为了处理类似“奏13+?”这种情况，留下13+给后面的逻辑处理
-                }
-                levelNumStr = levelNumStr.Replace("+", ".7");
-            }
-
-            float.TryParse(levelNumStr, out var levelNum);
+            MaiUtils.ParseLevelStr(data.Level, out var levelNum, out var utageKanji);
+            if (isUtage) music.UtageKanji = utageKanji;
             targetChart.LevelId = MaiUtils.GetLevelId((int)(levelNum * 10));
             // 忽略定数
             if (!ignoreLevelNum)

--- a/MaiChartManager/Controllers/Charts/Services/MaidataImportService.cs
+++ b/MaiChartManager/Controllers/Charts/Services/MaidataImportService.cs
@@ -192,7 +192,7 @@ public class MaidataImportService : IMaidataImportService
         }
         
         // 先执行第一步：Parser，因为可能涉及对Chart做出调整
-        List<(int lv, int targetLevel, MaidataLevel data, MaiChart chart, List<Alert> alerts)> parserOutput = [];
+        List<(int lv, int targetLevel, MaidataLevel data, MaiChart? chart, List<Alert> alerts)> parserOutput = [];
         foreach (var (lv, data) in maiData.Levels)
         {
             if (!targetLevelMap.ContainsKey(lv)) continue;
@@ -204,17 +204,22 @@ public class MaidataImportService : IMaidataImportService
             {
                 var parser = new SimaiParser(!isUtage && lv is 2 or 3, maiData.ClockCount);
                 var (chart, alerts) = parser.Parse(data.Inote);
+                if (chart.TotalNotes == 0)
+                {
+                    errors.Add(new ImportChartMessage(string.Format(Locale.ChartNoNotes, lv), MessageLevel.Warning));
+                    chart = null;
+                }
                 parserOutput.Add((lv, targetLevel, data, chart, alerts));
             }
             catch (ConversionException e)
             {
-                parserOutput.Add((lv, targetLevel, data, null!, e.Alerts));
+                parserOutput.Add((lv, targetLevel, data, null, e.Alerts));
                 MergeAlertsIntoImportChartMessages();
                 return new ImportChartResult(errors, true);
             }
         }
         
-        var chartPaddingDict = CalcChartPadding(parserOutput.Select(x=>x.chart).ToList());
+        var chartPaddingDict = CalcChartPadding(parserOutput.Where(x=>x.chart != null).Select(x=>x.chart!).ToList());
         var chartPadding = chartPaddingDict[shift]; // 当前所选择的模式所具体对应的chartPadding
 
         foreach (var c in music.Charts) { c.Enable = false; } // 先把所有难度标记为关闭（马上后面"第二步"的逻辑，会对存在的难度打开）
@@ -223,6 +228,7 @@ public class MaidataImportService : IMaidataImportService
         // 再执行第二步
         foreach (var (lv, targetLevel, data, chart, alerts) in parserOutput)
         {
+            if (chart == null) continue;
             var targetChart = music.Charts[targetLevel];
             targetChart.Path = $"{id:000000}_0{targetLevel}.ma2";
             

--- a/MaiChartManager/Locale.Designer.cs
+++ b/MaiChartManager/Locale.Designer.cs
@@ -215,6 +215,15 @@ namespace MaiChartManager {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Chart difficulty {0} has no notes. This difficulty will not be imported..
+        /// </summary>
+        internal static string ChartNoNotes {
+            get {
+                return ResourceManager.GetString("ChartNoNotes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to It looks like some notes were lost! This is likely a bug. We&apos;d really appreciate it if you could provide the chart file!.
         /// </summary>
         internal static string ChartNotesMissing {

--- a/MaiChartManager/Locale.resx
+++ b/MaiChartManager/Locale.resx
@@ -207,6 +207,9 @@ If you notice any issues with the conversion result, you can try testing it in A
     <data name="ChartDifficultyParseFailed" xml:space="preserve">
     <value>Failed to parse chart difficulty {0}</value>
   </data>
+  <data name="ChartNoNotes" xml:space="preserve">
+    <value>Chart difficulty {0} has no notes. This difficulty will not be imported.</value>
+  </data>
     <data name="ChartParseFailedGlobal" xml:space="preserve">
     <value>Chart parsing failed (global)</value>
   </data>

--- a/MaiChartManager/Locale.zh-hans.resx
+++ b/MaiChartManager/Locale.zh-hans.resx
@@ -199,6 +199,9 @@
     <data name="ChartDifficultyParseFailed" xml:space="preserve">
     <value>谱面难度 {0} 解析失败</value>
   </data>
+  <data name="ChartNoNotes" xml:space="preserve">
+    <value>谱面难度 {0} 中没有音符。将不会导入此难度。</value>
+  </data>
     <data name="ChartParseFailedGlobal" xml:space="preserve">
     <value>谱面解析失败（大）</value>
   </data>

--- a/MaiChartManager/Locale.zh-hant.resx
+++ b/MaiChartManager/Locale.zh-hant.resx
@@ -199,6 +199,9 @@
     <data name="ChartDifficultyParseFailed" xml:space="preserve">
     <value>譜面難度 {0} 解析失敗</value>
   </data>
+  <data name="ChartNoNotes" xml:space="preserve">
+    <value>譜面難度 {0} 中沒有音符。將不會匯入此難度。</value>
+  </data>
     <data name="ChartParseFailedGlobal" xml:space="preserve">
     <value>譜面解析失敗（大）</value>
   </data>

--- a/MaiChartManager/Utils/MaiUtils.cs
+++ b/MaiChartManager/Utils/MaiUtils.cs
@@ -12,7 +12,8 @@ public static partial class MaiUtils
     {
         utageKanji = "";
         value = 0;
-        if (string.IsNullOrEmpty(input)) return false;
+        input = input?.Trim();
+        if (string.IsNullOrWhiteSpace(input)) return false;
         
         if (!char.IsDigit(input[0]))
         { // 如果不以数字开头，说明是utageKanji的情况

--- a/MaiChartManager/Utils/MaiUtils.cs
+++ b/MaiChartManager/Utils/MaiUtils.cs
@@ -1,7 +1,31 @@
-﻿namespace MaiChartManager.Utils;
+﻿using System.Text.RegularExpressions;
 
-public static class MaiUtils
+namespace MaiChartManager.Utils;
+
+public static partial class MaiUtils
 {
+    [GeneratedRegex(@"^-?\d+(\.\d+)?")]
+    private static partial Regex LeadingFloatRegex();
+    
+    // 尝试解析字符串开头的浮点数部分，忽略后续无法解析的字符（如 "13?" -> 13）。
+    public static bool ParseLevelStr(string? input, out float value, out string utageKanji)
+    {
+        utageKanji = "";
+        value = 0;
+        if (string.IsNullOrEmpty(input)) return false;
+        
+        if (!char.IsDigit(input[0]))
+        { // 如果不以数字开头，说明是utageKanji的情况
+            utageKanji = input.Substring(0, 1);
+            input = input.Substring(1);
+        }
+        input = input.Replace("+", ".7");
+        
+        var match = LeadingFloatRegex().Match(input); // 结尾有可能会有一个?，或者是其他的什么东西。为了让这些东西不要影响处理，所以通过正则匹配开头的数字部分，不然如果直接送进float.TryParse的话，类似"13?"这种的就解析不出来、返回false了。
+        if (!match.Success) return false;
+        return float.TryParse(match.Value, System.Globalization.CultureInfo.InvariantCulture, out value);
+    }
+
     public static int GetLevelId(int levelX10)
     {
         return levelX10 switch


### PR DESCRIPTION
1. 之前的代码，当遇到物量为0的谱面时，会由于内部除0错误导致”谱面解析失败（大）“。现在改为，主动检查物量是否为0，如果为0则给警告并跳过此难度。
2. 之前代码对等级字符串的处理鲁棒性不足，具体而言：
   - 当模式没有被设为宴会场时，"宴13+?"这种就无法解析了
   - "12a"这种也无法解析，会返回0.0。但其实返回12才是更好的。

## Summary by Sourcery

在 maidata 导入过程中处理音轨中没有音符的谱面，并提升对 Utage 以及存在歧义难度的等级字符串解析鲁棒性。

Bug 修复：
- 略过那些虽然解析成功但实际包含零音符的谱面难度，在这种情况下仅输出警告，而不是导致后续流程报错。
- 确保当没有任何谱面难度能够被成功解析或导入时，导入检查依然会以致命错误失败。

功能增强：
- 优化谱面填充计算和导入流程，以忽略为 null 或无效的谱面。
- 引入可复用的工具，用于更鲁棒地解析等级字符串，包括 Utage 的汉字前缀、`+` 后缀以及类似 `?` 的尾随字符，并在计算 `LevelId` 时使用该工具。
- 为“谱面没有任何音符”的情况添加本地化的用户可见提示信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle charts with zero notes during maidata import and improve level string parsing robustness for Utage and ambiguous levels.

Bug Fixes:
- Skip importing chart difficulties that parse successfully but contain zero notes, emitting a warning instead of causing downstream errors.
- Ensure import checks still fail with a fatal error when no chart difficulties can be successfully parsed or imported.

Enhancements:
- Refine chart padding calculation and import flow to ignore null or invalid charts.
- Introduce a reusable utility to parse level strings more robustly, including Utage kanji prefixes, '+' suffixes, and trailing characters like '?', and use it when computing LevelId.
- Add localized user-facing messages for charts that have no notes.

</details>